### PR TITLE
Option to move mp4 file when all conversion and tagging is complete

### DIFF
--- a/postConversion.py
+++ b/postConversion.py
@@ -28,6 +28,11 @@ if len(sys.argv) > 4:
     tagmp4 = Tvdb_mp4(tvdb_id, season, episode)
     tagmp4.setHD(convert.width, convert.height)
     tagmp4.writeTags(path)
+    if (settings.move_dir is not None):
+        output_dir, filename = os.path.split(convert.output)
+        final_dest = os.path.join(settings.move_dir, filename)
+        os.rename(convert.output, final_dest)
+        print "Moving file to " + str(final_dest)
 else:
     print "Not enough command line arguments present " + str(len(sys.argv))
     sys.exit()

--- a/readSettings.py
+++ b/readSettings.py
@@ -22,7 +22,8 @@ class ReadSettings:
         self.output_dir = config.get("TVDB_MP4", "output_directory").replace("\\","\\\\").replace("\\\\\\\\","\\\\") #Output directory
         self.output_extension = config.get("TVDB_MP4", "output_extension") #Output extension
         self.delete = config.getboolean("TVDB_MP4", "delete_original") #Delete original file
-        
+        self.move_dir = config.get("TVDB_MP4", "move_directory").replace("\\","\\\\").replace("\\\\\\\\","\\\\") #Move directory
+
         #SSL
         self.protocol = "http://"
         if config.getboolean("TVDB_MP4", "ssl"):
@@ -37,7 +38,7 @@ class ReadSettings:
         else:
             if not os.path.isdir(self.output_dir):
                 os.makedirs(self.output_dir)
-            
+
     def getRefreshURL (self, tvdb_id):
         sickbeard_url = self.protocol + self.ip + ":" + self.port + "/api/" + self.api_key + "/?cmd=show.refresh&tvdbid=" + str(tvdb_id)
         return sickbeard_url

--- a/tvdb_mp4.ini
+++ b/tvdb_mp4.ini
@@ -8,3 +8,4 @@ ffprobe=ffprobe.exe
 output_directory=
 output_extension=mp4
 delete_original=True
+move_directory=


### PR DESCRIPTION
Another workaround for iTunes. Thank you so much for adding the "output directory" function, however it's not quite right for use with iTunes. The issue is that iTunes will detect the file before you've finished tagging it and you'll end up with an untagged file in iTunes. One way to get around this is to move the file when it's finished processing. With this patch I can set the output directory to I:\Temp and then the move directory / final destination to I:\Automatically Add to iTunes. Does this seem reasonable?
