### PR TITLE
Copy all streams, not just the first of each

### DIFF
--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -340,7 +340,7 @@ class FFMpeg(object):
         cmds.extend(opts)
         #Dirty injection to copy subtitles if present, implement this properly when you can
         cmds.extend(['-scodec', 'mov_text'])
-        cmds.extend(['-metadata:s:s:0', 'language=eng'])
+        cmds.extend(['-map', '0'])
         cmds.extend(['-y', outfile])
 
         def on_sigalrm(*args):


### PR DESCRIPTION
I've been trying to comment on Issue #6 but my comments seem to disappear, not sure if you've seen them. Anyway, this fixes the issue of only 1 subtitle stream being copied. It will also copy any additional audio tracks if they exist. I will submit an issue against python-video-converter for better subtitle support, but this will have to do for now.
