### PR TITLE
I think I fixed the poster issue..

### DIFF
--- a/tmdb_mp4.py
+++ b/tmdb_mp4.py
@@ -159,7 +159,7 @@ class tmdb_mp4:
     def getArtwork(self):
         #Pulls down all the poster metadata for the correct season and sorts them into the Poster object
         try:
-            poster = urllib.urlretrieve(self.movie.get_poster(), tempfile.gettempdir() + "\poster.jpg")[0]
+            poster = urllib.urlretrieve(self.movie.get_poster(), os.path.join(tempfile.gettempdir(),"poster.jpg"))[0]
         except:
             poster = None
         return poster

--- a/tvdb_mp4.py
+++ b/tvdb_mp4.py
@@ -151,7 +151,7 @@ class Tvdb_mp4:
                         poster.rating = float(self.showdata['_banners']['season']['season'][bannerid]['rating'])
                     poster.bannerpath = self.showdata['_banners']['season']['season'][bannerid]['_bannerpath']
                     posters.addPoster(poster)
-            poster = urllib.urlretrieve(posters.topPoster().bannerpath, tempfile.gettempdir() + "\poster.jpg")[0]
+            poster = urllib.urlretrieve(posters.topPoster().bannerpath, os.path.join(tempfile.gettempdir(),"poster.jpg"))[0]
         except:
             poster = None
         return poster


### PR DESCRIPTION
switched the generation of the tmp path for poster d/l to use the
os.path.join method to ensure compliance with OS pathing standards.
