### PR TITLE
Still having timeout problems from time to time...

### DIFF
--- a/mkvtomp4.py
+++ b/mkvtomp4.py
@@ -100,7 +100,7 @@ class MkvtoMp4:
 
             print options
             self.output = os.path.join(output_dir, filename + "." + output_extension)
-            conv = c.convert(file, self.output, options, False)
+            conv = c.convert(file, self.output, options, None)
 
             for timecode in conv:
                 pass


### PR DESCRIPTION
Based on the doc in the converter lib

"The optional timeout argument specifies how long should the operation
        be blocked in case ffmpeg gets stuck and doesn't report back. This
        doesn't limit the total conversion time, just the amount of time
        Converter will wait for each update from ffmpeg. As it's usually
        less than a second, the default of 10 is a reasonable default. To
        disable the timeout, set it to None. You may need to do this if
        using Converter in a threading environment, since the way the
        timeout is handled (using signals) has special restriction when
        using threads."
