### PR TITLE
Change to allow the user to keep iOS-style TV show artwork locally

### DIFF
--- a/tvdb_mp4.py
+++ b/tvdb_mp4.py
@@ -77,7 +77,12 @@ class Tvdb_mp4:
         video["----:com.apple.iTunes:iTunMOVI"] = self.xml  # XML - see xmlTags method
         video["----:com.apple.iTunes:iTunEXTC"] = self.setRating()  # iTunes content rating
 
-        path = self.getArtwork()
+        head, tail = os.path.split(os.path.abspath(mp4Path))
+        if (os.path.exists(head + '/' + "cover.jpg")):
+            path = head+ '/' + "cover.jpg"
+            print "Using local artwork: " + head + '/' + "cover.jpg"
+        else:
+            path = self.getArtwork()
         if path is not None:
             cover = open(path, 'rb').read()
             if path.endswith('png'):


### PR DESCRIPTION
You just need to drop a `cover.jpg` file into your Sickbeard paths (under `root_dirs`) or the same directory as your file and it will pick them up.  
- _(This is primarily for iOS devices since they only show square covers for TV shows but TVDB only provides portrait-styled images.)_
- _Ideally, this would be a setting where the file could be set arbitrarily to any valid image (i.e. PNG, JPG) I'm happy to add a more thorough version if there is interest in something like that._
