### PR TITLE
Add easier script for non-tv/movie files, and 2 features to control formatting for mp4/mov and mpeg4 files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ General Installation Instructions
     - `copy_to` = you may specify additional directories for the final product to be replicated to. This will be the last step performed so the file copied will be fully processed. Directories may be separated with a `|` character
     - `move_to` = you may specify one final directory to move the completed file. (Use this option for the 'Automatically Add to iTunes' folder)
     - `output_extension` = mp4/m4v (must be one of these 2)
+    - `output_format` = mp4/mov (must be one of these 2)  mov is better for large files in itunes, mp4 for windows / android
     - `delete_original` = True/False
     - `relocate_moov` = True/False - relocates the MOOV atom to the beginning of the file for better streaming
     - `ios-audio` = creates a 2nd copy of an audio stream that will be iOS compatible (AAC Stereo) if the normal output will not be. If a stereo source stream is detected with this option enabled, an AAC stereo stream will be the only one produced (essentially overriding the codec option) to avoid multiple stereo audio stream copies in different codecs.
@@ -36,6 +37,7 @@ General Installation Instructions
     - `convert-mp4` = forces the script to reprocess and convert mp4 files as though they were mkvs. Good if you have old mp4's that you want to match your current codec configuration.
     - `fullpathguess` = True/False - When manually processing a file, enable to guess metadata using the full path versus just the file name. (Files shows placed in a 'Movies' folder will be recognized as movies, not as TV shows for example.)
     - `tagfile` = True/False - Enable or disable tagging file with appropriate metadata after encoding.
+    - `allow-mpeg4` = True/False - If True, will remux instead of converting mpeg4 video (mpg4/xvid/divx) to h264
 
 SickBeard Installation Instructions
 --------------

--- a/autoProcess.ini.sample
+++ b/autoProcess.ini.sample
@@ -14,6 +14,7 @@ output_directory=
 copy_to=
 move_to=
 output_extension=mp4
+output_format=mov
 delete_original=True
 relocate_moov=True
 audio-codec=ac3
@@ -25,6 +26,7 @@ subtitle-default-language=
 fullpathguess=True
 convert-mp4=False
 tagfile=True
+allowMPEG4=False
 
 [CouchPotato]
 host = localhost

--- a/baseConvert.py
+++ b/baseConvert.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import autoProcessTV
+import datetime
+from readSettings import ReadSettings
+from mkvtomp4 import MkvtoMp4
+
+def Log(msg, *args):
+    s = msg % args
+    print datetime.datetime.now().strftime('%Y-%m-%d %H:%M ') + s
+
+settings = ReadSettings(os.path.dirname(sys.argv[0]), "autoProcess.ini")
+path = str(sys.argv[1])
+converter = MkvtoMp4(settings)
+converter.output_dir = None
+Log('Scanning folder [%s]', path)
+for r, d, f in os.walk(path):
+    for files in f:
+        inputfile = os.path.join(r, files)
+        if MkvtoMp4(settings).validSource(inputfile):
+            Log('Converting [%s]', inputfile)
+            output = converter.process(inputfile, True)
+            if settings.relocate_moov:
+                converter.QTFS(output['output'])
+            if settings.copyto:
+                converter.replicate(output['output'])
+        else :
+            Log('Skipped [%s]', inputfile)
+            

--- a/mkvtomp4.py
+++ b/mkvtomp4.py
@@ -9,7 +9,7 @@ from qtfaststart import processor, exceptions
 
 
 class MkvtoMp4:
-    def __init__(self, settings=None, FFMPEG_PATH="FFMPEG.exe", FFPROBE_PATH="FFPROBE.exe", delete=True, output_extension='mp4', output_dir=None, relocate_moov=True, video_codec='h264', audio_codec='aac', audio_bitrate=None, iOS=False, awl=None, swl=None, adl=None, sdl=None, processMP4=False, copyto=None, moveto=None):
+    def __init__(self, settings=None, FFMPEG_PATH="FFMPEG.exe", FFPROBE_PATH="FFPROBE.exe", delete=True, output_extension='mp4', output_dir=None, relocate_moov=True, video_codec='h264', audio_codec='aac', audio_bitrate=None, iOS=False, awl=None, swl=None, adl=None, sdl=None, processMP4=False, copyto=None, moveto=None, allowMPEG4=False, output_format='mp4'):
         # Settings
         self.FFMPEG_PATH=FFMPEG_PATH
         self.FFPROBE_PATH=FFPROBE_PATH
@@ -18,6 +18,8 @@ class MkvtoMp4:
         self.output_dir=output_dir
         self.relocate_moov=relocate_moov
         self.processMP4=processMP4
+        self.allowMPEG4=allowMPEG4
+        self.output_format = output_format
         self.copyto=copyto
         self.moveto=moveto
         self.relocate_moov=relocate_moov
@@ -45,6 +47,8 @@ class MkvtoMp4:
         self.output_dir=settings.output_dir
         self.relocate_moov=settings.relocate_moov
         self.processMP4=settings.processMP4
+        self.allowMPEG4=settings.allowMPEG4
+        self.output_format=settings.output_format
         self.copyto=settings.copyto
         self.moveto=settings.moveto
         self.relocate_moov = settings.relocate_moov
@@ -136,8 +140,10 @@ class MkvtoMp4:
         info = Converter(self.FFMPEG_PATH, self.FFPROBE_PATH).probe(inputfile)
        
         #Video stream
-        print "Video codec detected: " + info.video.codec
+        if (info.video.codec == 'mpeg4') and (self.allowMPEG4):   #switch type for mpeg4 when source is mpeg4 and switch is set to on
+            self.video_codec = info.video.codec
         vcodec = 'copy' if info.video.codec == self.video_codec else self.video_codec
+        print "Video codec detected: " + info.video.codec + ' (copy)' if vcodec=='copy' else ' (convert)'
 
         #Audio streams
         audio_settings = {}
@@ -158,7 +164,7 @@ class MkvtoMp4:
                             'map': a.index,
                             'codec': 'aac',
                             'channels': 2,
-                            'bitrate': 512,
+                            'bitrate': 192 if a.codec=='mp3' else 512,     #reduce bitrate to something reasonable if source is MP3.
                             'language': a.language,
                         }})
                         l += 1
@@ -169,7 +175,10 @@ class MkvtoMp4:
 
                 # Bitrate calculations/overrides
                 if self.audio_bitrate is None or self.audio_bitrate > (a.audio_channels * 256):
-                    abitrate = 256 * a.audio_channels
+                    if a.codec=='mp3':
+                        abitrate = 96 * a.audio_channels
+                    else:
+                        abitrate = 256 * a.audio_channels
                 else:
                     abitrate = self.audio_bitrate
 
@@ -231,8 +240,10 @@ class MkvtoMp4:
                             print "Ignoring %s external subtitle stream due to language: %s" % (fname, lang)
 
         # Collect all options
+        format = self.output_format
+        if info.video.codec == 'mpeg4': format = 'mp4'  #mpeg4 must be mp4 format, not mov format
         options = {
-            'format': 'mov',
+            'format': format,
             'video': {
                 'codec': vcodec,
                 'map': info.video.index,

--- a/readSettings.py
+++ b/readSettings.py
@@ -19,6 +19,7 @@ class ReadSettings:
                         'copy_to': '',
                         'move_to': '',
                         'output_extension': 'mp4',
+                        'output_format': 'mov',
                         'delete_original': 'True',
                         'relocate_moov': 'True',
                         'ios-audio': 'True',
@@ -28,6 +29,7 @@ class ReadSettings:
                         'audio-default-language': '',
                         'subtitle-default-language': '',
                         'convert-mp4': 'False',
+                        'allow-mpeg4': 'False',
                         'fullpathguess': 'True',
                         'tagfile': 'True'}
         # Default settings for CouchPotato
@@ -104,6 +106,7 @@ class ReadSettings:
                     self.moveto = None
 
         self.output_extension = config.get(section, "output_extension")  # Output extension
+        self.output_format = config.get(section, "output_format")  #format of output
         self.delete = config.getboolean(section, "delete_original")  # Delete original file
         self.relocate_moov = config.getboolean(section, "relocate_moov")  # Relocate MOOV atom to start of file
         self.acodec = config.get(section, "audio-codec").lower()  # Gets the desired audio codec, if no valid codec selected, default to AAC
@@ -140,6 +143,7 @@ class ReadSettings:
             if not os.path.isdir(self.output_dir):
                 os.makedirs(self.output_dir)
         self.processMP4 = config.getboolean(section, "convert-mp4")  # Determine whether or not to reprocess mp4 files or just tag them
+        self.allowMPEG4 = config.getboolean(section, "allow-mpeg4")  # Determine with mpeg4 (ie: divx/xvid) is an allowable final codec instead of h264
         self.fullpathguess = config.getboolean(section, "fullpathguess") # Guess using the full path or not
         self.tagfile = config.getboolean(section, "tagfile") # Tag files with metadata
 


### PR DESCRIPTION
- Added baseConvert.py to convert any video file without any
  tagging, directly from sabnzbd.  Recurses directories so can
  call directly to sweep a folder system instead of manual.py
- Added option to control mp4/mov format.  mov format is a problem on
  windows and (some?) android.
- Added option to remux mpeg4 video instead of converting to h264. This
  allows easy conversion from most AVI to MP4 files.  Note that for
  these files the output will always be mp4 format and not mov.
- Reduced default bitrate for AAC output when source is a MP3.  512
  is far too high for the common mp3 128kb source.
