### PR TITLE
add support for refreshing plex library after conversion

### DIFF
--- a/autoProcess.ini.sample
+++ b/autoProcess.ini.sample
@@ -39,3 +39,8 @@ apikey =
 delay = 65
 method = renamer
 delete_failed = 0
+
+[Plex]
+host = localhost
+port = 32400
+refresh_plex = False

--- a/plexRefresh.py
+++ b/plexRefresh.py
@@ -1,0 +1,29 @@
+import urllib
+from xml.dom import minidom
+
+def PlexRefresh(settings):
+    host = settings.Plex['host']
+    port = settings.Plex['port']
+
+    url = "http://%s:%s/library/sections" % (host, port)
+    try:
+        xml_sections = minidom.parse(urllib.urlopen(url))
+    except IOError, e:
+        print "Error: Count not contact Plex Media Server"
+        print e
+        return
+
+    sections = xml_sections.getElementsByTagName('Directory')
+    if not sections:
+        print "Error: Plex Media Server is not running"
+        return
+
+    for s in sections:
+        if s.getAttribute('type') == "show":
+            url = "http://%s:%s/library/sections/%s/refresh" % (host, port, s.getAttribute('key'))
+            try:
+                urllib.urlopen(url)
+            except Exception, e:
+                print "Error opening Plex refresh URL"
+                print e
+                return

--- a/postConversion.py
+++ b/postConversion.py
@@ -6,6 +6,7 @@ import urllib
 from readSettings import ReadSettings
 from tvdb_mp4 import Tvdb_mp4
 from mkvtomp4 import MkvtoMp4
+from plexRefresh import PlexRefresh
 settings = ReadSettings(os.path.dirname(sys.argv[0]), "autoProcess.ini")
 
 if len(sys.argv) > 4:
@@ -36,6 +37,9 @@ if len(sys.argv) > 4:
                 print refresh[item]
         except IOError:
             print "Couldn't refresh Sickbeard, check your settings"
+
+        if settings.Plex['refresh_plex']:
+            PlexRefresh(settings)
 
 else:
     print "Not enough command line arguments present " + str(len(sys.argv))

--- a/readSettings.py
+++ b/readSettings.py
@@ -43,8 +43,12 @@ class ReadSettings:
                        'delete_failed': 'False',
                        'ssl': 'False',
                        'web_root': ''}
+        # Default settings for Plex
+        plex_defaults = {'host': 'localhost',
+                         'port': '32400',
+                         'refresh_plex': 'False'}
 
-        defaults = {'SickBeard': sb_defaults, 'CouchPotato': cp_defaults, 'MP4': mp4_defaults}
+        defaults = {'SickBeard': sb_defaults, 'CouchPotato': cp_defaults, 'MP4': mp4_defaults, 'Plex': plex_defaults}
         write = False  # Will be changed to true if a value is missing from the config file and needs to be written
 
         config = ConfigParser.SafeConfigParser()
@@ -187,6 +191,16 @@ class ReadSettings:
                 self.CP['protocol'] = "http://"
         except (ConfigParser.NoOptionError, ValueError):
             self.CP['protocol'] = "http://"
+
+        #Read relevant Plex section information
+        section = "Plex"
+        self.Plex = {}
+        self.Plex['host'] = config.get(section, "host")
+        self.Plex['port'] = config.get(section, "port")
+        try:
+            self.Plex['refresh_plex'] = config.getboolean(section, "refresh_plex")
+        except (ConfigParser.NoOptionError, ValueError):
+            self.Plex['refresh_plex'] = False
 
         #Pass the values on
         self.config = config


### PR DESCRIPTION
Many Plex users make use of this script. Currently, due to the way it's run, sickbeard will only refresh the Plex library once when it has moved the file and not again when this script has finished its conversion. Because of this, Plex's knowledge of the file will be incorrect once the conversion is finished. This patch sends a refresh notification to Plex after the conversion is done to solve this issue.
