### PR TITLE
perform moov relocation always if relocate_moov is true

### DIFF
--- a/postConversion.py
+++ b/postConversion.py
@@ -24,7 +24,8 @@ if len(sys.argv) > 4:
             tagmp4.setHD(output['x'], output['y'])
             tagmp4.writeTags(output['output'])
 
-            #QTFS (only if file is tagged)
+        #QTFS
+        if settings.relocate_moov:
             converter.QTFS(output['output'])
 
         # Copy to additional locations


### PR DESCRIPTION
I see no reason that the moov relocation process cannot be run even if tagfile is False. This way you don't have to rewrite the file's metadata just to carry out the moov relocation process.
