### PR TITLE
Small fix to prevent re-encoding AAC

### DIFF
--- a/mkvtomp4.py
+++ b/mkvtomp4.py
@@ -197,7 +197,7 @@ class MkvtoMp4:
                         l += 1
                 # If the iOS audio option is enabled and the source audio channel is only stereo, the additional iOS channel will be skipped and a single AAC 2.0 channel will be made regardless of codec preference to avoid multiple stereo channels
                 if self.iOS and a.audio_channels == 2:
-                    acodec = 'copy' if a.codec == self.iOS else self.iOS
+                    acodec = 'copy' if a.codec == self.iOS or a.codec == 'aac' else self.iOS
                 else:
                     # If desired codec is the same as the source codec, copy to avoid quality loss
                     acodec = 'copy' if a.codec in self.audio_codec else self.audio_codec[0]


### PR DESCRIPTION
Currently, if the user specifies an alternative AAC encoder like libfdk, the audio is re-encoded.  This just prevents that so audio is copied from the original unchanged. 
