### PR TITLE
Fix for print statement in manual.py that can exception in certain cases

### DIFF
--- a/manual.py
+++ b/manual.py
@@ -180,7 +180,10 @@ def walkDir(dir, silent=False, output_dir=None):
             
             try:
                 if MkvtoMp4(settings).validSource(filepath):
-                    print "Processing file %s" % (filepath.encode(sys.stdout.encoding, errors='ignore'))
+                    try:
+                        print "Processing file %s" % (filepath.encode(sys.stdout.encoding, errors='ignore'))
+                    except:
+                        print "Processing file %s" % (filepath.encode('utf-8', errors='ignore'))
                     tagdata = getinfo(filepath, silent)
                     processFile(filepath, tagdata)
             except Exception as e:


### PR DESCRIPTION
sys.stdout.encoding can return None when script is called by sabnzbd as post-processing script, causing post-process to fail when it reaches this print statement
