### PR TITLE
compare actual files rather than file paths

### DIFF
--- a/mkvtomp4.py
+++ b/mkvtomp4.py
@@ -326,7 +326,7 @@ class MkvtoMp4:
         except UnicodeDecodeError:
             outputfile = os.path.join(output_dir, filename.decode('utf-8') + "." + self.output_extension)
         #If we're processing a file that's going to have the same input and output filename, resolve the potential future naming conflict
-        if inputfile == outputfile:
+        if self.samefile(inputfile, outputfile):
             newfile = os.path.join(input_dir, filename + '.tmp.' + input_extension)
             #Make sure there isn't any leftover temp files for whatever reason
             self.removeFile(newfile, 0, 0)
@@ -423,3 +423,9 @@ class MkvtoMp4:
                 if delay > 0:
                     time.sleep(delay)
         return False if os.path.isfile(filename) else True
+
+    def samefile(self, newFile, oldFile):
+        try:	
+	    return os.stat(newFile) == os.stat(oldFile)
+        except:
+	    return False


### PR DESCRIPTION
ran into an issue where `delete_original = True` and `convert-mp4 = True`, when the path given to the script is a relative path.

Currently, if the file is `/foo/bar/baz/`, and the path given is `./baz` inside of the `/foo/bar` path, the check is essentially `./baz == /foo/bar/baz`, which obviously fails, and as a result, the output file is "created" which overwrites the input, and then everything gets screwy.
