### PR TITLE
Added support for libfdk_aac.

### DIFF
--- a/mkvtomp4.py
+++ b/mkvtomp4.py
@@ -258,7 +258,7 @@ class MkvtoMp4:
                 if self.iOS:
                     if a.audio_channels > 2:
                         if self.iOS == 'libfdk_aac':
-                                self.log.info("Creating audio stream %s from source audio stream %s [iOS-audio]." % (str(l), a.index))
+                            self.log.info("Creating audio stream %s from source audio stream %s [iOS-audio]." % (str(l), a.index))
                             self.log.debug("Audio codec: %s." % self.iOS)
                             self.log.debug("Channels: 2.")
                             self.log.debug("Bitrate: 256.")

--- a/mkvtomp4.py
+++ b/mkvtomp4.py
@@ -257,19 +257,34 @@ class MkvtoMp4:
                 # Create iOS friendly audio stream if the default audio stream has too many channels (iOS only likes AAC stereo)
                 if self.iOS:
                     if a.audio_channels > 2:
-                        self.log.info("Creating audio stream %s from source audio stream %s [iOS-audio]." % (str(l), a.index))
-                        self.log.debug("Audio codec: %s." % self.iOS)
-                        self.log.debug("Channels: 2.")
-                        self.log.debug("Bitrate: 256.")
-                        self.log.debug("Language: %s" % a.metadata['language'])
-                        audio_settings.update({l: {
-                            'map': a.index,
-                            'codec': self.iOS,
-                            'channels': 2,
-                            'bitrate': 256,
-                            'language': a.metadata['language'],
-                        }})
-                        l += 1
+                        if self.iOS == 'libfdk_aac':
+                                self.log.info("Creating audio stream %s from source audio stream %s [iOS-audio]." % (str(l), a.index))
+                            self.log.debug("Audio codec: %s." % self.iOS)
+                            self.log.debug("Channels: 2.")
+                            self.log.debug("Bitrate: 256.")
+                            self.log.debug("Language: %s" % a.metadata['language'])
+                            audio_settings.update({l: {
+                                'map': a.index,
+                                'codec': self.iOS,
+                                'channels': 2,
+                                'vbr': 5,
+                                'language': a.metadata['language'],
+                            }})
+                            l += 1
+                        else:
+                            self.log.info("Creating audio stream %s from source audio stream %s [iOS-audio]." % (str(l), a.index))
+                            self.log.debug("Audio codec: %s." % self.iOS)
+                            self.log.debug("Channels: 2.")
+                            self.log.debug("Bitrate: 256.")
+                            self.log.debug("Language: %s" % a.metadata['language'])
+                            audio_settings.update({l: {
+                                'map': a.index,
+                                'codec': self.iOS,
+                                'channels': 2,
+                                'bitrate': 256,
+                                'language': a.metadata['language'],
+                            }})
+                            l += 1
                 # If the iOS audio option is enabled and the source audio channel is only stereo, the additional iOS channel will be skipped and a single AAC 2.0 channel will be made regardless of codec preference to avoid multiple stereo channels
                 self.log.info("Creating audio stream %s from source audio stream %s." % (str(l), a.index))
                 if self.iOS and a.audio_channels <= 2:

--- a/readSettings.py
+++ b/readSettings.py
@@ -211,7 +211,10 @@ class ReadSettings:
             self.iOS = False
         else:
             if self.iOS.lower() in ['true', 'yes', 't', '1']:
-                self.iOS = 'aac'
+                if 'libfdk_aac' in self.acodec:
+                    self.iOS = 'libfdk_aac'
+                else:
+                    self.iOS = 'aac'        
         self.iOSFirst = config.getboolean(section, "ios-first-track-only")  # Enables the iOS audio option only for the first track
         self.downloadsubs = config.getboolean(section, "download-subs")  #  Enables downloading of subtitles from the internet sources using subliminal
 


### PR DESCRIPTION
If libfdk_aac is part of the audio-codec list, then it will be used to
create the iOS friendly audio stream rather than the default aac, which
is a much lower quality codec.