### PR TITLE
Fix for invalid exit conditions for SickRage and Bypass categories

### DIFF
--- a/NZBGetPostProcess.py
+++ b/NZBGetPostProcess.py
@@ -195,9 +195,10 @@ if os.environ.has_key('NZBOP_SCRIPTDIR') and not os.environ['NZBOP_VERSION'][0:5
     elif (category.lower() == categories[3]):
         #DEBUG#print "Sickrage Processing Activated"
         autoProcessTVSR.processEpisode(path, settings, nzb)
+        sys.exit(POSTPROCESS_SUCCESS)
     elif (category.lower() == categories[4]):
         #DEBUG#print "Bypass Further Processing"
-        pass
+        sys.exit(POSTPROCESS_NONE)
 
 else:
     log.error("This script can only be called from NZBGet (11.0 or later).")


### PR DESCRIPTION
Exit code was not specified for both SickRage and Bypass conditions.  This was resulting in NZBGet treating the script as a failure even though it was successful.