### PR TITLE
Bug fix:  Add CRF value as a string

### DIFF
--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -639,7 +639,7 @@ class H264Codec(VideoCodec):
         if 'preset' in safe:
             optlist.extend(['-preset', safe['preset']])
         if 'quality' in safe:
-            optlist.extend(['-crf', safe['quality']])
+            optlist.extend(['-crf', str(safe['quality'])])
         if 'profile' in safe:
             optlist.extend(['-profile:v', safe['profile']])
         if 'level' in safe:


### PR DESCRIPTION
While adding support for using quality settings instead of constant bitrate, found this bug.  Without it, the _spawn() command errors out with:
'sequence item 9: expected string or Unicode, int found'