### PR TITLE
Quality settings

### DIFF
--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -640,7 +640,7 @@ class H264Codec(VideoCodec):
         if 'preset' in safe:
             optlist.extend(['-preset', safe['preset']])
         if 'quality' in safe:
-            optlist.extend(['-crf', safe['quality']])
+            optlist.extend(['-crf', str(safe['quality'])])
         if 'maxbitrate' in safe:
             optlist.extend(['-maxrate', str(safe['maxbitrate'])])
             optlist.extend(['-bufsize', str(safe['maxbitrate']*2)])

--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -642,8 +642,8 @@ class H264Codec(VideoCodec):
         if 'quality' in safe:
             optlist.extend(['-crf', str(safe['quality'])])
         if 'maxbitrate' in safe:
-            optlist.extend(['-maxrate', str(safe['maxbitrate'])])
-            optlist.extend(['-bufsize', str(safe['maxbitrate']*2)])
+            optlist.extend(['-maxrate', '%sk' % (str(safe['maxbitrate']))])
+            optlist.extend(['-bufsize', '%sk' % (str(safe['maxbitrate']*2))])
         if 'profile' in safe:
             optlist.extend(['-profile:v', safe['profile']])
         if 'level' in safe:

--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -618,6 +618,7 @@ class H264Codec(VideoCodec):
         'quality': int,  # constant rate factor, range:0(lossless)-51(worst)
         # default:23, recommended: 18-28
         # http://mewiki.project357.com/wiki/X264_Settings#profile
+        'maxbitrate': int, #default: not-set, maximum bitrate in kbps
         'profile': str,  # default: not-set, for valid values see above link
         'level': float, # default: not-set, values range from 3.0 to 4.2
         'tune': str,  # default: not-set, for valid values see above link
@@ -640,6 +641,9 @@ class H264Codec(VideoCodec):
             optlist.extend(['-preset', safe['preset']])
         if 'quality' in safe:
             optlist.extend(['-crf', safe['quality']])
+        if 'maxbitrate' in safe:
+            optlist.extend(['-maxrate', str(safe['maxbitrate'])])
+            optlist.extend(['-bufsize', str(safe['maxbitrate']*2)])
         if 'profile' in safe:
             optlist.extend(['-profile:v', safe['profile']])
         if 'level' in safe:

--- a/mkvtomp4.py
+++ b/mkvtomp4.py
@@ -501,7 +501,7 @@ class MkvtoMp4:
             del options['video']['bitrate']
             options['video']['quality'] = self.h264Quality if self.h264Quality else 20
             if self.video_bitrate is not None:  #set maximum bitrate if it's specified
-                options['video']['maxbitrate'] = int(vbitrate)
+                options['video']['maxbitrate'] = self.video_bitrate
         # Add width option
         if vwidth: options['video']['width'] = vwidth
 

--- a/mkvtomp4.py
+++ b/mkvtomp4.py
@@ -35,6 +35,7 @@ class MkvtoMp4:
                     scodec='mov_text',
                     downloadsubs=True,
                     processMP4=False,
+                    h264Quality=None,
                     copyto=None,
                     moveto=None,
                     embedsubs=True,
@@ -56,6 +57,7 @@ class MkvtoMp4:
         self.output_dir=output_dir
         self.relocate_moov=relocate_moov
         self.processMP4=processMP4
+        self.h264Quality=h264Quality
         self.copyto=copyto
         self.moveto=moveto
         self.relocate_moov=relocate_moov
@@ -94,6 +96,7 @@ class MkvtoMp4:
         self.output_dir=settings.output_dir
         self.relocate_moov=settings.relocate_moov
         self.processMP4=settings.processMP4
+        self.h264Quality=settings.h264Quality
         self.copyto=settings.copyto
         self.moveto=settings.moveto
         self.relocate_moov = settings.relocate_moov
@@ -493,6 +496,12 @@ class MkvtoMp4:
             'subtitle': subtitle_settings,
         }
 
+        #in h264, drop the constant bitrate and use the recommended quality settings.  ffmpeg default is 23 but our default is 20.
+        if vcodec == "h264":
+            del options['video']['bitrate']
+            options['video']['quality'] = self.h264Quality if self.h264Quality else 20
+            if self.video_bitrate is not None:  #set maximum bitrate if it's specified
+                options['video']['maxbitrate'] = int(vbitrate)
         # Add width option
         if vwidth: options['video']['width'] = vwidth
 

--- a/readSettings.py
+++ b/readSettings.py
@@ -61,6 +61,7 @@ class ReadSettings:
                         'subtitle-language': '',
                         'subtitle-default-language': '',
                         'convert-mp4': 'False',
+                        'h264Quality':'',
                         'fullpathguess': 'True',
                         'tagfile': 'True',
                         'tag-language': 'en',
@@ -277,6 +278,16 @@ class ReadSettings:
             except:
                 log.exception("Invalid video bitrate, defaulting to no video bitrate cap.")
                 self.vbitrate = None
+
+        self.h264Quality = config.get(section, "h264Quality")
+        if self.h264Quality == '':
+            self.h264Quality = None
+        else:
+            try:
+                self.h264Quality = int(self.h264Quality)
+            except:
+                log.exception("Invalid h264 Quality, using default quality.")
+                self.h264Quality = None
 
         self.vwidth = config.get(section, "video-max-width")
         if self.vwidth == '':


### PR DESCRIPTION
Using constant bit rate with x264 has been bugging me for a while.  Using the Quality Settings (which is the recommended approach) yields smaller and much better looking videos.

The downside is another configuration setting (which is what I implemented here).

When h264 is the output codec this patch will:
Remove the constant bit rate setting
Set the quality level to either default (20) or a value specified in the config file.
If video-bitrate is specified in config, that will be used as the max-bitrate

No issues so far.  All the videos I've been running it against look better and are smaller.
