### PR TITLE
ffmpeg output parser fix

### DIFF
--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -480,6 +480,10 @@ class FFMpeg(object):
                 signal.alarm(0)
 
             if not ret:
+                #For small or very fast jobs, ffmpeg may never output a '\r'.  When EOF is reached, yield if we haven't yet.
+                if not yielded:
+                    yielded = True
+                    yield 10
                 break
 
             try:


### PR DESCRIPTION
The ffmpeg parser expects '\r' in the output to yield to the caller.  For small or fast ffmpeg jobs, ffmpeg never outputs the '\r' so the job is detected as fails.

This patch handles the case where a job is finished but never yielded.  Seems to not mess with legitimate errors.