### PR TITLE
Add option to use QSV decoder with encoder and allow a few more extensions

### DIFF
--- a/autoProcess.ini.sample
+++ b/autoProcess.ini.sample
@@ -29,6 +29,7 @@ video-codec = h264,x264
 video-bitrate =
 video-max-width =
 h264-max-level =
+use-qsv-decoder-with-encoder = True
 ios-audio = True
 ios-first-track-only = False
 max-audio-channels =

--- a/extensions.py
+++ b/extensions.py
@@ -1,4 +1,4 @@
-valid_input_extensions = ['mkv', 'avi', 'ts', 'mov']
+valid_input_extensions = ['mkv', 'avi', 'ts', 'mov', 'vob', 'mpg']
 valid_output_extensions = ['mp4', 'm4v']
 valid_audio_codecs = ['aac', 'ac3', 'dts']
 valid_poster_extensions = ['jpg', 'png']

--- a/mkvtomp4.py
+++ b/mkvtomp4.py
@@ -23,6 +23,7 @@ class MkvtoMp4:
                  video_bitrate=None,
                  video_width=None,
                  h264_level=None,
+                 qsv_decoder=True,
                  audio_codec=['ac3'],
                  audio_bitrate=256,
                  iOS=False,
@@ -69,6 +70,7 @@ class MkvtoMp4:
         self.video_bitrate = video_bitrate
         self.video_width = video_width
         self.h264_level = h264_level
+        self.qsv_decoder = qsv_decoder
         self.pix_fmt = pix_fmt
         # Audio settings
         self.audio_codec = audio_codec
@@ -112,6 +114,7 @@ class MkvtoMp4:
         self.video_bitrate = settings.vbitrate
         self.video_width = settings.vwidth
         self.h264_level = settings.h264_level
+        self.qsv_decoder = settings.qsv_decoder
         self.pix_fmt = settings.pix_fmt
         # Audio settings
         self.audio_codec = settings.acodec
@@ -564,7 +567,7 @@ class MkvtoMp4:
         }
 
         # If using h264qsv, add the codec in front of the input for decoding
-        if vcodec == "h264qsv" and info.video.codec.lower() == "h264":
+        if vcodec == "h264qsv" and info.video.codec.lower() == "h264" and self.qsv_decoder:
             options['preopts'].extend(['-vcodec', 'h264_qsv'])
 
         # Add width option

--- a/mkvtomp4.py
+++ b/mkvtomp4.py
@@ -567,7 +567,7 @@ class MkvtoMp4:
         }
 
         # If using h264qsv, add the codec in front of the input for decoding
-        if vcodec == "h264qsv" and info.video.codec.lower() == "h264" and self.qsv_decoder:
+        if vcodec == "h264qsv" and info.video.codec.lower() == "h264" and self.qsv_decoder and (info.video.video_level / 10) < 5:
             options['preopts'].extend(['-vcodec', 'h264_qsv'])
 
         # Add width option

--- a/readSettings.py
+++ b/readSettings.py
@@ -75,6 +75,7 @@ class ReadSettings:
                         'video-bitrate': '',
                         'video-max-width': '',
                         'h264-max-level': '',
+                        'use-qsv-decoder-with-encoder': 'True',
                         'subtitle-codec': 'mov_text',
                         'subtitle-language': '',
                         'subtitle-default-language': '',
@@ -336,6 +337,7 @@ class ReadSettings:
                 log.exception("Invalid h264 level, defaulting to none.")
                 self.h264_level = None
 
+        self.qsv_decoder = config.getboolean(section, "use-qsv-decoder-with-encoder")  # Use Intel QuickSync Decoder when using QuickSync Encoder
         self.pix_fmt = config.get(section, "pix-fmt").strip().lower()
         if self.pix_fmt == '':
             self.pix_fmt = None


### PR DESCRIPTION
I've made a few changes that would allow the option to use the Intel QuickSync decoder with the encoder by using a setting. I have a few files that refuse to transcode the video with the default settings (they seem to be encoded with a h.264 level of 5), and making this change fixed the problem for me. I'm new to python programming, so if there's a way to read the level through ffprobe and make the change based on that, that may be easier, but I figured this way allowed it to be easily changed. I'm also not sure if maybe newer processors with QuickSync support higher levels.

I also added a couple more extensions because I had a few files that I couldn't transcode without making these changes as well.