### PR TITLE
Allow extensions to be in uppercase or lowercase

### DIFF
--- a/extensions.py
+++ b/extensions.py
@@ -1,4 +1,4 @@
-valid_input_extensions = ['mkv', 'avi', 'ts', 'mov', 'vob', 'mpg']
+valid_input_extensions = ['mkv', 'avi', 'ts', 'mov', 'vob', 'mpg', 'mts']
 valid_output_extensions = ['mp4', 'm4v']
 valid_audio_codecs = ['aac', 'ac3', 'dts']
 valid_poster_extensions = ['jpg', 'png']

--- a/mkvtomp4.py
+++ b/mkvtomp4.py
@@ -206,7 +206,7 @@ class MkvtoMp4:
     def validSource(self, inputfile):
         input_dir, filename, input_extension = self.parseFile(inputfile)
         # Make sure the input_extension is some sort of recognized extension, and that the file actually exists
-        if (input_extension in valid_input_extensions or input_extension in valid_output_extensions):
+        if (input_extension.lower() in valid_input_extensions or input_extension.lower() in valid_output_extensions):
             if (os.path.isfile(inputfile)):
                 self.log.debug("%s is valid." % inputfile)
                 return True
@@ -221,7 +221,7 @@ class MkvtoMp4:
     def needProcessing(self, inputfile):
         input_dir, filename, input_extension = self.parseFile(inputfile)
         # Make sure input and output extensions are compatible. If processMP4 is true, then make sure the input extension is a valid output extension and allow to proceed as well
-        if (input_extension in valid_input_extensions or (self.processMP4 is True and input_extension in valid_output_extensions)) and self.output_extension in valid_output_extensions:
+        if (input_extension.lower() in valid_input_extensions or (self.processMP4 is True and input_extension.lower() in valid_output_extensions)) and self.output_extension.lower() in valid_output_extensions:
             self.log.debug("%s needs processing." % inputfile)
             return True
         else:


### PR DESCRIPTION
Extensions in uppercase from my Canon 60D were not processed unless they were made lowercase, this fixes that problem.