### PR TITLE
Allow multiple subtitle formats, add SSA subtitles

### DIFF
--- a/converter/formats.py
+++ b/converter/formats.py
@@ -107,9 +107,15 @@ class WebVTTFormat(BaseFormat):
     format_name = 'webvtt'
     ffmpeg_format_name = 'webvtt'
 
+class SsaFormat(BaseFormat):
+    """
+    SSA subtitle format
+    """
+    format_name = 'ass'
+    ffmpeg_format_name = 'ass'
 
 format_list = [
     OggFormat, AviFormat, MkvFormat, WebmFormat, FlvFormat,
     MovFormat, Mp4Format, MpegFormat, Mp3Format, SrtFormat,
-    WebVTTFormat
+    WebVTTFormat, SsaFormat
 ]

--- a/extensions.py
+++ b/extensions.py
@@ -2,13 +2,14 @@ valid_input_extensions = ['mkv', 'avi', 'ts', 'mov', 'vob', 'mpg', 'mts']
 valid_output_extensions = ['mp4', 'm4v']
 valid_audio_codecs = ['aac', 'ac3', 'dts']
 valid_poster_extensions = ['jpg', 'png']
-valid_subtitle_extensions = ['srt', 'vtt']
+valid_subtitle_extensions = ['srt', 'vtt', 'ass']
 valid_formats = ['mp4', 'mov']
 bad_subtitle_codecs = ['pgssub', 'dvdsub', 's_hdmv/pgs']
 tmdb_api_key = "45e408d2851e968e6e4d0353ce621c66"
 valid_internal_subcodecs = ['mov_text']
-valid_external_subcodecs = ['srt', 'webvtt']
+valid_external_subcodecs = ['srt', 'webvtt', 'ass']
 subtitle_codec_extensions = {'srt': 'srt',
-                             'webvtt': 'vtt'}
+                             'webvtt': 'vtt',
+                             'ass': 'ass'}
 bad_post_files = ['resources', '.DS_Store']
 bad_post_extensions = ['.txt', '.log', '.pyc']

--- a/readSettings.py
+++ b/readSettings.py
@@ -353,18 +353,29 @@ class ReadSettings:
         self.scodec = config.get(section, 'subtitle-codec').strip().lower()
         if not self.scodec or self.scodec == "":
             if self.embedsubs:
-                self.scodec = 'mov_text'
+                self.scodec = ['mov_text']
             else:
-                self.scodec = 'srt'
+                self.scodec = ['srt']
             log.warning("Invalid subtitle codec, defaulting to '%s'." % self.scodec)
+        else:
+            self.scodec = self.scodec.replace(' ', '').split(',')
 
-        if self.embedsubs and self.scodec not in valid_internal_subcodecs:
-            log.warning("Invalid interal subtitle codec %s, defaulting to 'mov_text'." % self.scodec)
-            self.scodec = 'mov_text'
+        if self.embedsubs:
+            if len(self.scodec) > 1:
+                log.warning("Can only embed one subtitle type, defaulting to 'mov_text'.")
+                self.scodec = ['mov_text']
+            if self.scodec[0] not in valid_internal_subcodecs:
+                log.warning("Invalid interal subtitle codec %s, defaulting to 'mov_text'." % self.scodec[0])
+                self.scodec = ['mov_text']
+        else:
+            for codec in self.scodec:
+                if not codec in valid_external_subcodecs:
+                    log.warning("Invalid external subtitle codec %s, ignoring." % codec)
+                    self.scodec.remove(codec)
 
-        if not self.embedsubs and self.scodec not in valid_external_subcodecs:
-            log.warning("Invalid external subtitle codec %s, defaulting to 'srt'." % self.scodec)
-            self.scodec = 'srt'
+            if len(self.scodec) == 0:
+                log.warning("No valid subtitle formats found, defaulting to 'srt'.")
+                self.scodec = ['srt']
 
         self.swl = config.get(section, 'subtitle-language').strip().lower()  # List of acceptable languages for subtitle streams to be carried over from the original file, separated by a comma. Blank for all
         if self.swl == '':


### PR DESCRIPTION
This allows specifying multiple subtitle formats when exporting subtitles, for example `srt,ass`, and adds SSA (`.ass`) as a valid export format.  My use-case is certain anime that comes with SSA subtitles - I want to export them as srt for certain underpowered clients but also preserve the SSA subtitles and their special effects for players that can handle them.