### PR TITLE
poster download filename collision

### DIFF
--- a/postCouchPotato.py
+++ b/postCouchPotato.py
@@ -28,6 +28,12 @@ log.debug("Original file name: %s" % original)
 
 try:
     log.info('Processing file: %s', inputfile)
+    log.info('Moving file from %s to %s', inputfile, inputfile.lower())
+    os.rename(inputfile, inputfile.lower())
+    log.info('Resetting input file variable')
+    inputfile = inputfile.lower()
+    log.info('Processing input file: %s', inputfile)
+
     if MkvtoMp4(settings).validSource(inputfile):
         log.info('File is valid')
         output = converter.process(inputfile, original=original)

--- a/tmdb_mp4.py
+++ b/tmdb_mp4.py
@@ -195,8 +195,9 @@ class tmdb_mp4:
         # Pulls down all the poster metadata for the correct season and sorts them into the Poster object
         if poster is None:
             try:
-                poster = urlretrieve(self.movie.get_poster("l"), os.path.join(tempfile.gettempdir(), "poster.jpg"))[0]
+                poster = urlretrieve(self.movie.get_poster("l"), os.path.join(tempfile.gettempdir(), "poster-tmdb.jpg"))[0]
             except:
+                self.log.error("Exception while retrieving poster %s.", str(err))
                 poster = None
         return poster
 

--- a/tvdb_mp4.py
+++ b/tvdb_mp4.py
@@ -206,8 +206,9 @@ class Tvdb_mp4:
         if poster is None:
             if thumbnail:
                 try:
-                    poster = urlretrieve(self.episodedata['filename'], os.path.join(tempfile.gettempdir(), "poster.jpg"))[0]
+                    poster = urlretrieve(self.episodedata['filename'], os.path.join(tempfile.gettempdir(), "poster-tvdb.jpg"))[0]
                 except:
+                    self.log.error("Exception while retrieving poster %s.", str(err))
                     poster = None
             else:
                 posters = posterCollection()


### PR DESCRIPTION
By using a different filename for tvdb poster downloads and tmdb poster downloads we avoid rights issues when poster.jpeg is created with a the 700 chmod option while users for couchpotato and sonarr are different.

Fixes #475