### PR TITLE
Fix error UnboundLocalError for 'lang'

### DIFF
--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -456,14 +456,13 @@ class AudioCopyCodec(BaseCodec):
             optlist.extend(['-map', s + ':' + str(safe['map'])])
         if 'bsf' in safe:
             optlist.extend(['-bsf:a:' + stream, str(safe['bsf'])])
+        lang = 'und'
         if 'language' in safe:
             l = safe['language']
             if len(l) > 3:
                 del safe['language']
             else:
                 lang = str(safe['language'])
-        else:
-            lang = 'und'
         optlist.extend(['-metadata:s:a:' + stream, "language=" + lang])
         if 'disposition' in safe:
             optlist.extend(['-disposition:a:' + stream, str(safe['disposition'])])


### PR DESCRIPTION
Fix UnboundLocalError for variable 'lang', which is created in the scope of the if blocks, but referenced from outside the blocks, resulting in an error.

```
File "/downloads/sickbeard_mp4_automator/converter/avcodecs.py", line 467, in parse_options
optlist.extend(['-metadata:s:a:' + stream, "language=" + lang])
UnboundLocalError: local variable 'lang' referenced before assignment
```