### PR TITLE
Resolves errors when installing PIP Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Default Settings
 2. Audio - AAC 2.0 with additional AC3 track when source has >2 channels (ex 5.1)
 3. Subtitles - mov_text
 
-Prerequesite PIP Package Installation Instructions
+Prerequesite PIP Package Installation Instructions (Windows users should enter commands in Powershell - using '<' doesn't work in cmd)
 --------------
 - `VC for Python 2.7` (Windows Users Only) - Download and install - http://www.microsoft.com/en-us/download/details.aspx?id=44266
 - `setup_tools` - https://pypi.python.org/pypi/setuptools#installation-instructions
@@ -40,7 +40,7 @@ Prerequesite PIP Package Installation Instructions
 - `requests-cache` - Run `pip install requests-cache`
 - `babelfish` - Run `pip install babelfish`
 - `guessit` - Run `pip install guessit<2` to use manual.py (requires guessit version 1, version 2 is a complete rewrite, still in alpha, and not backwards compatible)
-- `subliminal`- Run `pip install subliminal<2` to enable automatically downloading subtitles
+- `subliminal`- Run `pip install subliminal<2` to enable automatically downloading subtitles 
 - `stevedore` - Run `pip install stevedore` (this will be automatically installed with subliminal)
 - `dateutil` - Run `pip install python-dateutil` (this will be automatically installed with subliminal)
 - `deluge-client` Run `pip install deluge-client` if you plan on using Deluge

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Default Settings
 2. Audio - AAC 2.0 with additional AC3 track when source has >2 channels (ex 5.1)
 3. Subtitles - mov_text
 
-Prerequesite PIP Package Installation Instructions (Windows users should enter commands in Powershell - using '<' doesn't work in cmd)
+Prerequesite PIP Package Installation Instructions
 --------------
+Note: Windows users should enter commands in Powershell - using '<' doesn't work in cmd
 - `VC for Python 2.7` (Windows Users Only) - Download and install - http://www.microsoft.com/en-us/download/details.aspx?id=44266
 - `setup_tools` - https://pypi.python.org/pypi/setuptools#installation-instructions
 - `requests` - Run `pip install requests`


### PR DESCRIPTION
When you try to install guessit<2 and subliminal<2, cmd doesn't understand '<' and gives an error.