### PR TITLE
Fix progress bar showing on 1 line

### DIFF
--- a/mkvtomp4.py
+++ b/mkvtomp4.py
@@ -629,7 +629,8 @@ class MkvtoMp4:
             for timecode in conv:
                 if reportProgress:
                     try:
-                        sys.stdout.write('[{0}] {1}%\r'.format('#' * (timecode / 10) + ' ' * (10 - (timecode / 10)), timecode))
+                        sys.stdout.write('\r')
+                        sys.stdout.write('[{0}] {1}%'.format('#' * (timecode / 10) + ' ' * (10 - (timecode / 10)), timecode))
                     except:
                         sys.stdout.write(str(timecode))
                     sys.stdout.flush()


### PR DESCRIPTION
The \r doesn't seem to work in Python 3 or at least isn't working the way it's suppose to. Putting it before the progress write and writing it by itself seems to fix the issue.

Also I'm not really a Python programmer, so if there's something wrong with this that I don't notice let me know!