### PR TITLE
Fix for <Actor "None"> being returned for some shows from TVDB

### DIFF
--- a/tvdb_mp4.py
+++ b/tvdb_mp4.py
@@ -166,7 +166,7 @@ class Tvdb_mp4:
         # Write actors
         output.write(castheader)
         for a in self.showdata['_actors'][:5]:
-            if a is not None:
+            if a is not None and a['name'] is not None:
                 output.write("<dict><key>name</key><string>%s</string></dict>\n" % a['name'].encode('ascii', errors='ignore'))
         output.write(subfooter)
 


### PR DESCRIPTION
* This happens for a few shows including Family Guy, American Dad and
  led to tagging and conversion failing completely. TVDB returns an
  "Actor" object, so "a" is not None, but the "a" dict contains
  Actor "None" which cannot be encoded on the next line:
  ` a['name'].encode(...)`