### PR TITLE
Add support for Dolby Digital Plus audio passthrough

### DIFF
--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -582,6 +582,20 @@ class Ac3Codec(AudioCodec):
                 opt['channels'] = 6
         return super(Ac3Codec, self).parse_options(opt, stream)
 
+class EAc3Codec(AudioCodec):
+    """
+    Dolby Digital Plus/EAC3 audio codec.
+    """
+    codec_name = 'eac3'
+    ffmpeg_codec_name = 'eac3'
+
+    def parse_options(self, opt, stream=0):
+        if 'channels' in opt:
+            c = opt['channels']
+            if c > 6:
+                opt['channels'] = 6
+        return super(EAc3Codec, self).parse_options(opt, stream)
+
 
 class FlacCodec(AudioCodec):
     """
@@ -907,7 +921,7 @@ class DVDSub(SubtitleCodec):
 
 audio_codec_list = [
     AudioNullCodec, AudioCopyCodec, VorbisCodec, AacCodec, Mp3Codec, Mp2Codec,
-    FdkAacCodec, FAacCodec, Ac3Codec, DtsCodec, FlacCodec
+    FdkAacCodec, FAacCodec, EAc3Codec, Ac3Codec, DtsCodec, FlacCodec
 ]
 
 video_codec_list = [

--- a/extensions.py
+++ b/extensions.py
@@ -1,6 +1,6 @@
 valid_input_extensions = ['mkv', 'avi', 'ts', 'mov', 'vob', 'mpg', 'mts']
 valid_output_extensions = ['mp4', 'm4v']
-valid_audio_codecs = ['aac', 'ac3', 'dts']
+valid_audio_codecs = ['aac', 'ac3', 'dts','eac3']
 valid_poster_extensions = ['jpg', 'png']
 valid_subtitle_extensions = ['srt', 'vtt', 'ass']
 valid_formats = ['mp4', 'mov']


### PR DESCRIPTION
* The [fourth generation AppleTV](http://www.apple.com/apple-tv/specs/) supports Dolby Digital Plus passthrough and it's used for shows from Amazon Prime, Netflix, among others. (_The Grand Tour_ being a notable example. )
* If you have a fourth gen AppleTV, you can add it to supported codecs:
  `audio-codec = ac3,libfdk_aac,aac,eac3` 
to pass through without re-encoding and get the full 5.1 or 7.1 channel sound. 

Note:
The only caveat is that _encoding_ must be done at a different bitrate than Dolby Digital... right now
the bitrate is hardcoded in `avcodecs.py` to `br = 1536` for all surround codecs but it 
needs to be `br = 640` for encoding to DD+ or it will produce bad audio. This is only an issue if you were converted from say, DTS to EAC3. 
 