### PR TITLE
Enhancements for Dolby Digital Plus support/conversion

### DIFF
--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -592,8 +592,12 @@ class EAc3Codec(AudioCodec):
     def parse_options(self, opt, stream=0):
         if 'channels' in opt:
             c = opt['channels']
-            if c > 6:
-                opt['channels'] = 6
+            if c > 8:
+                opt['channels'] = 8
+        if 'bitrate' in opt:
+            br = opt['bitrate']
+            if br > 640:
+                opt['bitrate'] = 640
         return super(EAc3Codec, self).parse_options(opt, stream)
 
 


### PR DESCRIPTION
Changes:
* DD+ supports 7.1 (for a total of 8 channels) so allow that
* Bitrate needs to be 640kb/s in ffmpeg or only noise is produced,
  this overrides the 1536k set on line 81 and produces files playable
  on (at least) fourth generation AppleTVs, and other devices with
  DD+ support
* DD+ also works with Dolby Audio for headphones/mobile
* In theory, the resulting files should have better quality audio when
  the audio is converted from a higher quality codec like DTS/DTS-MA

Additional Notes:
* Just set the first`audio-codec` to `eac3` to enable conversion
* More info and specs for the curious here: [Dolby Digital Plus](https://www.dolby.com/us/en/technologies/dolby-digital-plus.html)
