### PR TITLE
Add experimental flag for flac encoding.

### DIFF
--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -606,6 +606,10 @@ class FlacCodec(AudioCodec):
     """
     codec_name = 'flac'
     ffmpeg_codec_name = 'flac'
+    flac_experimental_enable = ['-strict', 'experimental']
+
+    def _codec_specific_produce_ffmpeg_list(self, safe, stream=0):
+        return self.flac_experimental_enable
 
 
 class DtsCodec(AudioCodec):


### PR DESCRIPTION
By [this thread](http://www.ffmpeg-archive.org/Firefox-supports-MP4-FLAC-tp4679143p4679147.html) the latest builds of ffmpeg support flac in the mp4 container using the `-strict -2` or `-strict experimental` flag similar to what mp4 automator [is doing for aac encoding](https://github.com/mdhiggins/sickbeard_mp4_automator/blob/bf2bba60527e1fac57b28b5455fb6fed9aa71995/converter/avcodecs.py#L542-L551).