### PR TITLE
Add VAAPI support

### DIFF
--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -716,6 +716,18 @@ class NVEncH264(H264Codec):
     codec_name = 'nvenc_h264'
     ffmpeg_codec_name = 'nvenc_h264'
 
+class H264VAAPI(H264Codec):
+    """
+    H.264/AVC video codec.
+    """
+    codec_name = 'h264vaapi'
+    ffmpeg_codec_name = 'h264_vaapi'
+
+    def _codec_specific_produce_ffmpeg_list(self, safe, stream=0):
+        optlist = []
+        optlist.extend(['-vaapi_device', '/dev/dri/renderD128'])
+        optlist.extend(['-vf', "format=nv12,hwupload"])
+        return optlist
 
 class H264QSV(H264Codec):
     """
@@ -924,7 +936,7 @@ audio_codec_list = [
 ]
 
 video_codec_list = [
-    VideoNullCodec, VideoCopyCodec, TheoraCodec, H264Codec, H264QSV, H265Codec,
+    VideoNullCodec, VideoCopyCodec, TheoraCodec, H264Codec, H264QSV, H264VAAPI, H265Codec,
     DivxCodec, Vp8Codec, H263Codec, FlvCodec, Mpeg1Codec, NVEncH264, NVEncH265,
     Mpeg2Codec
 ]


### PR DESCRIPTION
Fixes #626 

To use it, alter: `video-codec = h264` to `video-codec = h264vaapi,h264`
Mine looks like this `video-codec = h264vaapi,h264,x264,h265,x265,hevc`

You need to list the vaapi codec first to trigger it apparently.

Tested with AVI -> MP4 and MKV -> MP4

There is no h264_vaapi decoder, only vdpau from what i've seen, so hardware decoding is probably out of the question, but someone smarter than me can probably figure that out ;)