### PR TITLE
Fix original path deletion in Deluge Post Process

### DIFF
--- a/delugePostProcess.py
+++ b/delugePostProcess.py
@@ -122,11 +122,7 @@ settings = ReadSettings(os.path.dirname(sys.argv[0]), "autoProcess.ini")
 # Delete original path
 if settings.delete:
 	for filename in files:
-<<<<<<< HEAD
 		inputfile = os.path.join(originputpath, filename)
-=======
-		inputfile = os.path.join(origpath, filename)
->>>>>>> master
 		try:
 			converter.removeFile(inputfile)
 			log.info("Successfully removed original file %s." % inputfile)
@@ -141,11 +137,7 @@ if settings.delete:
 # Delete conversion path
 if delete_dir:
     if os.path.exists(delete_dir):
-<<<<<<< HEAD
 		tempfiles = os.listdir(delete_dir)
-=======
-		tempfiles = os.listdir(dir)
->>>>>>> master
 		for filename in tempfiles:
 			file = os.path.join(path, filename)
 			try:

--- a/delugePostProcess.py
+++ b/delugePostProcess.py
@@ -21,9 +21,10 @@ if len(sys.argv) < 4:
     log.error("Not enough command line parameters present, are you launching this from deluge?")
     sys.exit()
 
-path = str(sys.argv[3])
+path = originputpath = str(sys.argv[3])
 torrent_name = str(sys.argv[2])
 torrent_id = str(sys.argv[1])
+origpath = os.path.join(path, torrent_name)
 delete_dir = None
 
 log.debug("Path: %s." % path)
@@ -115,10 +116,37 @@ elif (category == categories[4]):
 elif (category == categories[5]):
     log.info("Bypassing any further processing as per category.")
 
+# Reset back to user preferences
+settings = ReadSettings(os.path.dirname(sys.argv[0]), "autoProcess.ini")
+
+# Delete original path
+if settings.delete:
+	for filename in files:
+		inputfile = os.path.join(originputpath, filename)
+		try:
+			converter.removeFile(inputfile)
+			log.info("Successfully removed original file %s." % inputfile)
+		except:
+			log.exception("Unable to delete original file %s." % inputfile)
+	try:
+		os.rmdir(origpath)
+		log.debug("Successfully removed original directory %s." % origpath)
+	except:
+		log.exception("Unable to delete original directory %s." % origpath)
+	
+# Delete conversion path
 if delete_dir:
     if os.path.exists(delete_dir):
-        try:
-            os.rmdir(delete_dir)
-            log.debug("Successfully removed tempoary directory %s." % delete_dir)
-        except:
-            log.exception("Unable to delete temporary directory.")
+		tempfiles = os.listdir(delete_dir)
+		for filename in tempfiles:
+			file = os.path.join(path, filename)
+			try:
+				converter.removeFile(file)
+				log.debug("Successfully removed tempoary file %s." % file)
+			except:
+				log.exception("Unable to delete temporary file %s." % file)
+		try:
+			os.rmdir(delete_dir)
+			log.debug("Successfully removed tempoary directory %s." % delete_dir)
+		except:
+			log.exception("Unable to delete temporary directory %s." % delete_dir)


### PR DESCRIPTION
I've fixed the delugePostProcess.py to now include original path deletion which it didn't seem to have before for some reason. Also made the temporary folder deletion first delete all files within dir, then dir itself since it was causing an issue on Windows.