### PR TITLE
Fix regression from previous commit

### DIFF
--- a/mkvtomp4.py
+++ b/mkvtomp4.py
@@ -661,7 +661,7 @@ class MkvtoMp4:
             options['preopts'].extend(['-hwaccel', 'dxva2'])
         elif info.video.codec.lower() == "hevc" and self.hevc_qsv_decoder:
             options['preopts'].extend(['-vcodec', 'hevc_qsv'])
-        elif info.video.codec.lower() == "h264" and self.qsv_decoder and (info.video.video_level / 10) < 5:
+        elif vcodec == "h264qsv" and info.video.codec.lower() == "h264" and self.qsv_decoder and (info.video.video_level / 10) < 5:
             options['preopts'].extend(['-vcodec', 'h264_qsv'])
 
         # Add width option


### PR DESCRIPTION
https://github.com/mdhiggins/sickbeard_mp4_automator/commit/7dfd4e17d89de43bcdad1868a1e25ab7c44597d6
- Forgot that the default setting for use-qsv-decoder-with-encoder was True
- Fixes https://github.com/mdhiggins/sickbeard_mp4_automator/issues/818

Would it make more sense to not have the h264qsv decoder require that the h264qsv encoder is being used? Example being decoding a h264 video and then encoding into h265. 