### PR TITLE
Remove lookahead from hevc_qsv encoder, as it doesn't support the opt…

### DIFF
--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -817,11 +817,6 @@ class HEVCQSV(H265Codec):
     codec_name = 'hevcqsv'
     ffmpeg_codec_name = 'hevc_qsv'
 
-    def _codec_specific_produce_ffmpeg_list(self, safe, stream=0):
-        optlist = []
-        optlist.extend(['-look_ahead', '0'])
-        return optlist
-
 
 class NVEncH265(H265Codec):
     """


### PR DESCRIPTION
…ion even if it's set to 0

Sorry for the multiple PRs, I don't have an easy way of testing qsv stuff. 