### PR TITLE
Handling of language codes

### DIFF
--- a/languagecode.py
+++ b/languagecode.py
@@ -25,7 +25,7 @@ def getAlpha3TCode(code):  # We need to make sure that language codes are alpha3
     elif len(code) == 2:
         lang = Language.fromalpha2(code).alpha3t
 
-    return str(lang)
+    return lang
 
 
 def validateLangCode(code):

--- a/languagecode.py
+++ b/languagecode.py
@@ -1,0 +1,48 @@
+from babelfish import Language
+
+
+def getAlpha3TCode(code):  # We need to make sure that language codes are alpha3T
+    """
+        :param    code: Alpha2, Alpha3, or Alpha3b code.
+        :type     code: C{str}
+
+        :return: Alpha3t language code (ISO 639-2/T) as C{str}
+    """
+    lang = None
+    code = code.strip().lower()
+    if len(code) == 3:
+        try:
+            lang = Language(code).alpha3t
+        except:
+            try:
+                lang = Language.fromalpha3b(code).alpha3t
+            except:
+                try:
+                    lang = Language.fromalpha3t(code).alpha3t
+                except:
+                    pass
+
+    elif len(code) == 2:
+        lang = Language.fromalpha2(code).alpha3t
+
+    return str(lang)
+
+
+def validateLangCode(code):
+    """
+    :param code: alpha2, alpha3 or alpha3b code or list of codes
+    :type code: list or string
+    :return:  list or string containing valid alpha3 codes
+    """
+    lang = None
+    if isinstance(code, list):
+        lang = list(set(map(getAlpha3TCode, code)))
+        try:
+            lang.remove(None)
+        except ValueError:
+            pass
+        lang = None if lang == [] else lang
+    elif isinstance(code, basestring):
+        lang = getAlpha3TCode(code)
+
+    return lang

--- a/languagecode.py
+++ b/languagecode.py
@@ -1,5 +1,8 @@
+import sys
+
 from babelfish import Language
 
+IS_PY2 = sys.version_info[0] == 2
 
 def getAlpha3TCode(code):  # We need to make sure that language codes are alpha3T
     """
@@ -38,10 +41,13 @@ def validateLangCode(code):
     lang = 'und'
     if code:
         if isinstance(code, list):
-            lang = filter(lambda x: x != 'und', list(set(map(getAlpha3TCode, code))))
+            lang = list(filter(lambda x: x != 'und', set(map(getAlpha3TCode, code))))
             lang = 'und' if lang == [] else lang
-
-        elif isinstance(code, basestring):
-            lang = getAlpha3TCode(code)
+        elif IS_PY2:
+            if isinstance(code, basestring):
+                lang = getAlpha3TCode(code)
+        else:
+            if isinstance(code, bytes):
+                lang = getAlpha3TCode(code)
 
     return lang

--- a/languagecode.py
+++ b/languagecode.py
@@ -8,8 +8,9 @@ def getAlpha3TCode(code):  # We need to make sure that language codes are alpha3
 
         :return: Alpha3t language code (ISO 639-2/T) as C{str}
     """
-    lang = None
+    lang = 'und'
     code = code.strip().lower()
+
     if len(code) == 3:
         try:
             lang = Language(code).alpha3t
@@ -34,15 +35,13 @@ def validateLangCode(code):
     :type code: list or string
     :return:  list or string containing valid alpha3 codes
     """
-    lang = None
-    if isinstance(code, list):
-        lang = list(set(map(getAlpha3TCode, code)))
-        try:
-            lang.remove(None)
-        except ValueError:
-            pass
-        lang = None if lang == [] else lang
-    elif isinstance(code, basestring):
-        lang = getAlpha3TCode(code)
+    lang = 'und'
+    if code:
+        if isinstance(code, list):
+            lang = filter(lambda x: x != 'und', list(set(map(getAlpha3TCode, code))))
+            lang = 'und' if lang == [] else lang
+
+        elif isinstance(code, basestring):
+            lang = getAlpha3TCode(code)
 
     return lang

--- a/readSettings.py
+++ b/readSettings.py
@@ -9,6 +9,7 @@ except ImportError:
 import logging
 from extensions import *
 from babelfish import Language
+import languagecode
 
 
 class ReadSettings:
@@ -402,10 +403,7 @@ class ReadSettings:
             self.pix_fmt = self.pix_fmt.replace(' ', '').split(',')
 
         self.awl = config.get(section, 'audio-language').strip().lower()  # List of acceptable languages for audio streams to be carried over from the original file, separated by a comma. Blank for all
-        if self.awl == '':
-            self.awl = None
-        else:
-            self.awl = self.awl.replace(' ', '').split(',')
+        self.awl = languagecode.validateLangCode(self.awl.replace(' ', '').split(','))
 
         self.scodec = config.get(section, 'subtitle-codec').strip().lower()
         if not self.scodec or self.scodec == "":
@@ -435,22 +433,15 @@ class ReadSettings:
                 self.scodec = ['srt']
 
         self.swl = config.get(section, 'subtitle-language').strip().lower()  # List of acceptable languages for subtitle streams to be carried over from the original file, separated by a comma. Blank for all
-        if self.swl == '':
-            self.swl = None
-        else:
-            self.swl = self.swl.replace(' ', '').split(',')
+        self.swl = languagecode.validateLangCode(self.swl.replace(' ', '').split(','))
 
         self.subencoding = config.get(section, 'subtitle-encoding').strip().lower()
         if self.subencoding == '':
             self.subencoding = None
 
-        self.adl = config.get(section, 'audio-default-language').strip().lower()  # What language to default an undefinied audio language tag to. If blank, it will remain undefined. This is useful for single language releases which tend to leave things tagged as und
-        if self.adl == "" or len(self.adl) > 3:
-            self.adl = None
+        self.adl = languagecode.validateLangCode(config.get(section, 'audio-default-language'))  # What language to default an undefined audio language tag to. If blank, it will remain undefined. This is useful for single language releases which tend to leave things tagged as und
+        self.sdl = languagecode.validateLangCode(config.get(section, 'subtitle-default-language'))  # What language to default an undefined subtitle language tag to. If blank, it will remain undefined. This is useful for single language releases which tend to leave things tagged as und
 
-        self.sdl = config.get(section, 'subtitle-default-language').strip().lower()  # What language to default an undefinied subtitle language tag to. If blank, it will remain undefined. This is useful for single language releases which tend to leave things tagged as und
-        if self.sdl == ""or len(self.sdl) > 3:
-            self.sdl = None
         # Prevent incompatible combination of settings
         if self.output_dir == "" and self.delete is False:
             log.error("You must specify an alternate output directory if you aren't going to delete the original file.")


### PR DESCRIPTION
Hi,

I have a recurring problem with subtitles embedded in mkv files. Quite often, they are coded using alpha3b codes, e.g. using 'fre' when the alpha3 code is 'fra' for French.
The problem is:
- If I don't include 'fre' in the swl list, the subtitles do not get picked up 
- If I include 'fre' in the swl list, then the subtitles get picked up, but the mkvtomp4 script errors on line 555, because babelfish expects alpha3 codes, not alpha3b codes. (NB: this does not happen with audio, where I can include both codes).

I did some research, and the spec for mp4 is that yet another ISO standard should be used, namely alpha3t (ISO-639-2/T) (you can see it [here](http://standards.iso.org/ittf/PubliclyAvailableStandards/c041828_ISO_IEC_14496-12_2005(E).zip), in section 8.8)

I thought it was a good idea to set things up so that:
swl, awl, sdl, and adl  all use alpha3t code and then convert the subtitle.metadata['language'] and audio.metadata['language'], to alpha3t codes too, to make sure that equivalent things are compared. Otherwise, users would need to put all codes in autoProcess.ini to make sure that they include their language in the processed file, which also leads to unnecessary iterations in the various loops (checking once for 'fre', and once for 'fra' is inefficient).

French is not the only language with this problem, Chinese, Dutch, German and other languages have different alpha3b and alpha3 codes too.

Please, do tell me if you want me to amend the code. I am not a professional developer, so things may be inelegant, or there just might be a better way that I just don't know about. I'm happy to improve.

Thanks you and kind regards,

Jon