### PR TITLE
Tiny correction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ General MP4 Configuration
     - `download-subs` = True/False - When enabled the script will attempt to download subtitles of your specified languages automatically using subliminal and merge them into the final mp4 file.
     **YOU MUST INSTALL SUBLIMINAL AND ITS DEPENDENCIES FOR THIS TO WORK.** You must run `pip install subliminal` in order for this feature to be enabled.
     - `sub-providers` = Comma separated values for potential subtitle providers. Must specify at least 1 provider to enable `download-subs`. Providers include `podnapisi` `thesubdb` `opensubtitles` `tvsubtitles` `addic7ed`
-    - `preopts` = Additional unsupported options that go before the rest of the FFMPEG parameters, comma separated (Example `-preset, medium`)
+    - `preopts` = Additional unsupported options that go before the rest of the FFMPEG parameters, comma separated (Example `-preset,medium`)
     - `postopts` = Additional unsupported options that go after the rest of the FFMEPG parameters, comma separated as above
 
 Sickbeard Setup


### PR DESCRIPTION
The whitespace in "-preset, medium" caused FFmpeg to abort.