### PR TITLE
Sonarr V3 Script Test

### DIFF
--- a/postSonarr.py
+++ b/postSonarr.py
@@ -13,7 +13,10 @@ from post_processor import PostProcessor
 from logging.config import fileConfig
 
 logpath = '/var/log/sickbeard_mp4_automator'
-if os.name == 'nt':
+if os.environ.get('sonarr_eventtype') == "Test":
+    print "Sonarr event type is Test"
+    sys.exit(0)
+elif os.name == 'nt':
     logpath = os.path.dirname(sys.argv[0])
 elif not os.path.isdir(logpath):
     try:


### PR DESCRIPTION
Made postSonarr.py script compatible with Sonarr V3 by implementing correct script exit if Sonarr event type is true, otherwise the script could never be successful added to Sonarr.
Tested working with Sonarr V3, original functionality of Sonarr V2 also tested and still works as intended.

P.s thanks to Desimaniac for pointing me in the right direction on how to fix it.