### PR TITLE
Add support for qBittorrent

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Downloaders Supported:
 - SABNZBD
 - NZBGet
 - uTorrent
+- qBittorrent
 - Deluge Daemon
 
 Requirements
@@ -47,6 +48,7 @@ Note: Windows users should enter commands in Powershell - using '<' doesn't work
 - `dateutil` - Run `pip install python-dateutil` (this will be automatically installed with subliminal)
 - `deluge-client` Run `pip install deluge-client` if you plan on using Deluge
 - `qtfaststart` Run `pip install qtfaststart` to enable moving moov atom
+- `python-qbittorrent` Run `pip install python-qbittorrent` to enable support for qBittorrent
 
 General MP4 Configuration
 --------------
@@ -268,6 +270,28 @@ uTorrent Setup
     - `hostname` - your uTorrent Web UI URL, eg `http://localhost:8080/` including the trailing slash.
     - `username` - your uTorrent Web UI username.
     - `password` - your uTorrent Web UI password.
+5. Verify that whatever media manager you are using is assigning the label to match the label settings specified here so that file will be passed back to the appropriate location
+
+qBittorrent Setup
+--------------
+1. Verify that you have installed the **python-qbittorrent library**
+    - `pip install python-qbittorrent`
+2. Launch qBittorrent
+3. Set `Run Program` option
+    - Go to `Tools > Options > Run external program on torrent completion`
+    - Point to `qBittorrentPostProcess.py` with command line parameters: `"%L" "%T" "%R" "%F" "%N" "%I"` in that exact order.
+4. Set your qBittorrent settings in autoProcess.ini
+    - `convert` - `True`/`False`. Allows for conversion of files before passing back to the respective download manager.
+    - `sickbeard-label` - default `sickbeard` - qBittorrent label that should be assigned to torrents that will be sent to Sickbeard for additional processing when download is complete.
+    - `sickrage-label` - default `sickrage` - qBittorrent label that should be assigned to torrents that will be sent to Sickrage for additional processing when download is complete.
+    - `couchpotato-label` - default `couchpotato` - qBittorrent label that should be assigned to torrents that will be sent to Couch Potato for additional processing when download is complete.
+    - `sonarr-label` - default `sonarr` - qBittorrent label that should be assigned to torrents that will be sent to Sonarr for additional processing when download is complete.
+    - `bypass-label` - default `bypass` - label that should be assigned to torrents that will not be sent anywhere when download is complete. Useful if you wish to convert files without additional processing.
+    - `action_before` - pause
+    - `action_after` - pause/delete
+    - `hostname` - your qBittorrent Web UI URL, eg `http://localhost:8080/` including the trailing slash.
+    - `username` - your qBittorrent Web UI username.
+    - `password` - your qBittorrent Web UI password.
 5. Verify that whatever media manager you are using is assigning the label to match the label settings specified here so that file will be passed back to the appropriate location
 
 Deluge Daemon

--- a/autoProcess.ini.sample
+++ b/autoProcess.ini.sample
@@ -99,6 +99,20 @@ username =
 password =
 output_directory =
 
+[qBittorrent]
+convert =
+couchpotato-label = couchpotato
+sickbeard-label = sickbeard
+sonarr-label = sonarr
+bypass-label = bypass
+sickrage-label = sickrage
+action_before = pause
+action_after = resume
+host = http://localhost:8080/
+username =
+password =
+output_directory =
+
 [Deluge]
 host = localhost
 username =

--- a/qBittorrentPostProcess.py
+++ b/qBittorrentPostProcess.py
@@ -23,13 +23,6 @@ log = logging.getLogger("qBittorrentPostProcess")
 
 log.info("qBittorrent post processing started.")
 
-# %L: Category - label
-# %T: Current tracker - tracker
-# %R: Root path (first torrent subdirectory path) - directory
-# %F: Content path (same as root path for multifile torrent) - single|multi
-# %N: Torrent name - name
-# %I: Info hash
-
 if len(sys.argv) != 7:
     log.error("Not enough command line parameters present, are you launching this from qBittorrent?")
     log.error("#Args: %L %T %R %F %N %I Category, Tracker, RootPath, ContentPath , TorrentName, InfoHash")
@@ -55,7 +48,6 @@ if root_path == content_path:
     single_file = False
 else:
     single_file = True
-
 
 if label not in categories:
     log.error("No valid label detected.")

--- a/qBittorrentPostProcess.py
+++ b/qBittorrentPostProcess.py
@@ -1,0 +1,200 @@
+import os
+import re
+import sys
+import shutil
+from autoprocess import autoProcessTV, autoProcessMovie, autoProcessTVSR, sonarr, radarr
+from readSettings import ReadSettings
+from mkvtomp4 import MkvtoMp4
+import logging
+from logging.config import fileConfig
+
+logpath = '/var/log/sickbeard_mp4_automator'
+if os.name == 'nt':
+    logpath = os.path.dirname(sys.argv[0])
+elif not os.path.isdir(logpath):
+    try:
+        os.mkdir(logpath)
+    except:
+        logpath = os.path.dirname(sys.argv[0])
+configPath = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), 'logging.ini')).replace("\\", "\\\\")
+logPath = os.path.abspath(os.path.join(logpath, 'index.log')).replace("\\", "\\\\")
+fileConfig(configPath, defaults={'logfilename': logPath})
+log = logging.getLogger("qBittorrentPostProcess")
+
+log.info("qBittorrent post processing started.")
+
+# %L: Category - label
+# %T: Current tracker - tracker
+# %R: Root path (first torrent subdirectory path) - directory
+# %F: Content path (same as root path for multifile torrent) - single|multi
+# %N: Torrent name - name
+# %I: Info hash
+
+if len(sys.argv) != 7:
+    log.error("Not enough command line parameters present, are you launching this from qBittorrent?")
+    log.error("#Args: %L %T %R %F %N %I Category, Tracker, RootPath, ContentPath , TorrentName, InfoHash")
+    log.error("Length was %s" % str(len(sys.argv)))
+    log.error(str(sys.argv[1:]))
+    sys.exit()
+
+settings = ReadSettings(os.path.dirname(sys.argv[0]), "autoProcess.ini")
+label = sys.argv[1].lower()
+root_path = str(sys.argv[3])
+content_path = str(sys.argv[4])
+name = sys.argv[5]
+torrent_hash = sys.argv[6]
+categories = [settings.qBittorrent['cp'], settings.qBittorrent['sb'], settings.qBittorrent['sonarr'], settings.qBittorrent['radarr'], settings.qBittorrent['sr'], settings.qBittorrent['bypass']]
+
+log.debug("Root Path: %s." % root_path)
+log.debug("Label: %s." % label)
+log.debug("Categories: %s." % categories)
+log.debug("Torrent hash: %s." % torrent_hash)
+log.debug("Torrent name: %s." % name)
+
+if root_path == content_path:
+    single_file = False
+else:
+    single_file = True
+
+
+if label not in categories:
+    log.error("No valid label detected.")
+    sys.exit()
+
+if len(categories) != len(set(categories)):
+    log.error("Duplicate category detected. Category names must be unique.")
+    sys.exit()
+
+# Import python-qbittorrent
+try:
+    from qbittorrent import Client
+except ImportError:
+    log.exception("Python module PYTHON-QBITTORRENT is required. Install with 'pip install python-qbittorrent' then try again.")
+    sys.exit()    
+
+delete_dir = False
+
+qb = Client(settings.qBittorrentHost)
+
+if settings.qBittorrentActionBefore:
+  qb.login(settings.qBittorrentUsername, settings.qBittorrentPassword)
+  if settings.qBittorrentActionBefore == 'pause': #currently only support pausing
+    log.debug("Sending action %s to qBittorrent" % settings.qBittorrentActionBefore)
+    qb.pause(torrent_hash)
+
+if settings.qBittorrent['convert']:
+    # Check for custom qBittorrent output_dir
+    if settings.qBittorrent['output_dir']:
+        settings.output_dir = settings.qBittorrent['output_dir']
+        log.debug("Overriding output_dir to %s." % settings.qBittorrent['output_dir'])
+
+    # Perform conversion.
+    log.info("Performing conversion")
+    settings.delete = False
+    if not settings.output_dir:
+      #If the user hasn't set an output directory, go up one from the root path and create a directory there as [name]-convert
+      suffix = "convert"
+      settings.output_dir = os.path.abspath(os.path.join(root_path, '..', ("%s-%s" % (name, suffix))))
+      if not os.path.exists(settings.output_dir):
+          os.mkdir(settings.output_dir)
+      delete_dir = settings.output_dir
+
+    converter = MkvtoMp4(settings)
+
+    if single_file:
+        #single file
+        inputfile = content_path
+        if MkvtoMp4(settings).validSource(inputfile):
+            log.info("Processing file %s." % inputfile)
+            try:
+                output = converter.process(inputfile, reportProgress=True)
+            except:
+                log.exception("Error converting file %s." % inputfile)
+        else:
+            log.debug("Ignoring file %s." % inputfile)
+    else:
+        log.debug("Processing multiple files.")
+        ignore = []
+        for r, d, f in os.walk(root_path):
+            for files in f:
+                inputfile = os.path.join(r, files)
+                if MkvtoMp4(settings).validSource(inputfile) and inputfile not in ignore:
+                    log.info("Processing file %s." % inputfile)
+                    try:
+                        output = converter.process(inputfile)
+                        if output is not False:
+                            ignore.append(output['output'])
+                        else:
+                            log.error("Converting file failed %s." % inputfile)
+                    except:
+                        log.exception("Error converting file %s." % inputfile)
+                else:
+                    log.debug("Ignoring file %s." % inputfile)
+
+    path = converter.output_dir
+else:
+    suffix = "copy"
+    # name = name[:260-len(suffix)]
+    if single_file:
+        log.info("Single File Torrent")
+        newpath = os.path.join(path, ("%s-%s" % (name, suffix)))
+    else:
+        log.info("Multi File Torrent")
+        newpath = os.path.abspath(os.path.join(root_path, '..', ("%s-%s" % (name, suffix))))
+    
+    if not os.path.exists(newpath):
+        os.mkdir(newpath)
+        log.debug("Creating temporary directory %s" % newpath)
+    
+    if single_file:
+        inputfile = content_path
+        shutil.copy(inputfile, newpath)
+        log.debug("Copying %s to %s" % (inputfile, newpath))
+    else:
+        for r, d, f in os.walk(root_path):
+            for files in f:
+                inputfile = os.path.join(r, files)
+                shutil.copy(inputfile, newpath)
+                log.debug("Copying %s to %s" % (inputfile, newpath))
+    path = newpath
+    delete_dir = newpath
+
+if label == categories[0]:
+    log.info("Passing %s directory to Couch Potato." % path)
+    autoProcessMovie.process(path, settings)
+elif label == categories[1]:
+    log.info("Passing %s directory to Sickbeard." % path)
+    autoProcessTV.processEpisode(path, settings)
+elif label == categories[2]:
+    log.info("Passing %s directory to Sonarr." % path)
+    sonarr.processEpisode(path, settings)
+elif label == categories[3]:
+    log.info("Passing %s directory to Radarr." % path)
+    radarr.processMovie(path, settings)
+elif label == categories[4]:
+    log.info("Passing %s directory to Sickrage." % path)
+    autoProcessTVSR.processEpisode(path, settings)
+elif label == categories[5]:
+    log.info("Bypassing any further processing as per category.")
+
+# Run a qbittorrent action after conversion.
+if settings.qBittorrentActionAfter:
+    qb.login(settings.qBittorrentUsername, settings.qBittorrentPassword)
+    #currently only support resuming or deleting torrent
+    if settings.qBittorrentActionAfter == 'resume': 
+        log.debug("Sending action %s to qBittorrent" % settings.qBittorrentActionBefore)
+        qb.resume(torrent_hash)
+    elif settings.qBittorrentActionAfter == 'delete':
+        #this will delete the torrent from qBittorrent but it WILL NOT delete the data
+        log.debug("Sending action %s to qBittorrent" % settings.qBittorrentActionBefore)
+        qb.delete(torrent_hash)
+
+if delete_dir:
+    if os.path.exists(delete_dir):
+        try:
+            os.rmdir(delete_dir)
+            log.debug("Successfully removed tempoary directory %s." % delete_dir)
+        except:
+            log.exception("Unable to delete temporary directory")
+
+sys.exit()

--- a/qBittorrentPostProcess.py
+++ b/qBittorrentPostProcess.py
@@ -89,7 +89,6 @@ if settings.qBittorrent['convert']:
       settings.output_dir = os.path.abspath(os.path.join(root_path, '..', ("%s-%s" % (name, suffix))))
       if not os.path.exists(settings.output_dir):
           os.mkdir(settings.output_dir)
-      delete_dir = settings.output_dir
 
     converter = MkvtoMp4(settings)
 

--- a/readSettings.py
+++ b/readSettings.py
@@ -113,8 +113,7 @@ class ReadSettings:
                         'post-process': 'False',
                         'pix-fmt': '',
                         'preopts': '',
-                        'postopts': '',
-                        'exit-on-fail': 'False'}
+                        'postopts': ''}
         # Default settings for CouchPotato
         cp_defaults = {'host': 'localhost',
                        'port': '5050',
@@ -520,10 +519,6 @@ class ReadSettings:
         else:
             self.postopts = self.postopts.split(',')
             [o.strip() for o in self.postopts]
-        
-        self.exit_on_fail = config.getboolean(section, "exit-on-fail")
-        if self.exit_on_fail == '':
-            self.exit_on_fail = False
 
         # Read relevant CouchPotato section information
         section = "CouchPotato"

--- a/readSettings.py
+++ b/readSettings.py
@@ -113,7 +113,8 @@ class ReadSettings:
                         'post-process': 'False',
                         'pix-fmt': '',
                         'preopts': '',
-                        'postopts': ''}
+                        'postopts': '',
+                        'exit-on-fail': 'False'}
         # Default settings for CouchPotato
         cp_defaults = {'host': 'localhost',
                        'port': '5050',
@@ -519,6 +520,10 @@ class ReadSettings:
         else:
             self.postopts = self.postopts.split(',')
             [o.strip() for o in self.postopts]
+        
+        self.exit_on_fail = config.getboolean(section, "exit-on-fail")
+        if self.exit_on_fail == '':
+            self.exit_on_fail = False
 
         # Read relevant CouchPotato section information
         section = "CouchPotato"
@@ -572,6 +577,30 @@ class ReadSettings:
         self.uTorrentHost = config.get(section, "host").lower()
         self.uTorrentUsername = config.get(section, "username")
         self.uTorrentPassword = config.get(section, "password")
+
+        # Read relevant qBittorrent section information
+        section = "qBittorrent"
+        self.qBittorrent = {}
+        self.qBittorrent['cp'] = config.get(section, "couchpotato-label").lower()
+        self.qBittorrent['sb'] = config.get(section, "sickbeard-label").lower()
+        self.qBittorrent['sr'] = config.get(section, "sickrage-label").lower()
+        self.qBittorrent['sonarr'] = config.get(section, "sonarr-label").lower()
+        self.qBittorrent['radarr'] = config.get(section, "radarr-label").lower()
+        self.qBittorrent['bypass'] = config.get(section, "bypass-label").lower()
+        try:
+            self.qBittorrent['convert'] = config.getboolean(section, "convert")
+        except:
+            self.qBittorrent['convert'] = False
+        self.qBittorrent['output_dir'] = config.get(section, "output_directory")
+        if self.qBittorrent['output_dir'] == '':
+            self.qBittorrent['output_dir'] = None
+        else:
+            self.qBittorrent['output_dir'] = os.path.normpath(self.raw(self.qBittorrent['output_dir']))  # Output directory        
+        self.qBittorrentActionBefore = config.get(section, "action_before").lower()
+        self.qBittorrentActionAfter = config.get(section, "action_after").lower()
+        self.qBittorrentHost = config.get(section, "host").lower()
+        self.qBittorrentUsername = config.get(section, "username")
+        self.qBittorrentPassword = config.get(section, "password")
 
         # Read relevant Deluge section information
         section = "Deluge"


### PR DESCRIPTION
This PR adds support for qBittorrent.  I borrowed heavily from the uTorrent script.  There is a new dependency (`pip install python-qbittorrent`) to allow interaction with qBittorrent easier so we don't have to make the requests ourselves.

- Only `pause` is supported for the `Before` action.
- Only `resume` or `delete` is supported for the `After` action.
