### PR TITLE
Added more verbose percent-completion messaging

### DIFF
--- a/converter/__init__.py
+++ b/converter/__init__.py
@@ -241,7 +241,7 @@ class Converter(object):
             optlist = self.parse_options(options, twopass)
             for timecode in self.ffmpeg.convert(infile, outfile, optlist,
                                                 timeout=timeout, preopts=preopts, postopts=postopts):
-                yield int((100.0 * timecode) / info.format.duration)
+                yield (float((100.0 * timecode) / info.format.duration), info.format.duration)
 
     def probe(self, fname, posters_as_video=True):
         """

--- a/mkvtomp4.py
+++ b/mkvtomp4.py
@@ -776,7 +776,8 @@ class MkvtoMp4:
                 if reportProgress:
                     try:
                         sys.stdout.write('\r')
-                        sys.stdout.write('[{0}] {1}%'.format('#' * (timecode / 10) + ' ' * (10 - (timecode / 10)), timecode))
+                        percent = '{0:.2f}%'.format(timecode[0], timecode[1]).zfill(6)
+                        sys.stdout.write(percent)
                     except:
                         sys.stdout.write(str(timecode))
                     sys.stdout.flush()


### PR DESCRIPTION
Made percent-completion output messages use 2 whole number integers and 2 decimal points, through some formatting and Converter.convert yield value changes.
Example image of an encoding task reaching 11.93%: 
![image](https://user-images.githubusercontent.com/14364070/67261632-8a478180-f46f-11e9-9560-b22746bc3c31.png)

The largest value that gets printed is 99.99% before the program continues with the remaining tasks.
