### PR TITLE
Option to add unsupported codec for subtitles #1100

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ General MP4 Configuration
     - `download-subs` = True/False - When enabled the script will attempt to download subtitles of your specified languages automatically using subliminal and merge them into the final mp4 file.
     **YOU MUST INSTALL SUBLIMINAL AND ITS DEPENDENCIES FOR THIS TO WORK.** You must run `pip install subliminal` in order for this feature to be enabled.
     - `sub-providers` = Comma separated values for potential subtitle providers. Must specify at least 1 provider to enable `download-subs`. Providers include `podnapisi` `thesubdb` `opensubtitles` `tvsubtitles` `addic7ed`
+    - `additional_bad_subtitle_codecs` = Comma separated values for potential additional unsupported subtitles codec. By default the list is the following: `pgssub`, `dvdsub`, `s_hdmv/pgs`, `dvd_subtitle`, `pgssub`, `dvb_teletext`, `dvb_subtitle`. MKV can use other codec. Add additional codec not handled by the code if you are encountering the error `Subtitle encoding currently only possible from text to text or bitmap to bitmap` when using ffmpeg. You can analyze the file's subtitles using ffprobe.
     - `preopts` = Additional unsupported options that go before the rest of the FFMPEG parameters, comma separated (Example `-preset,medium`)
     - `postopts` = Additional unsupported options that go after the rest of the FFMEPG parameters, comma separated as above
 

--- a/autoProcess.ini.sample
+++ b/autoProcess.ini.sample
@@ -68,6 +68,7 @@ download-subs = False
 embed-subs = True
 embed-only-internal-subs = False
 sub-providers = addic7ed,podnapisi,thesubdb,opensubtitles
+additional_bad_subtitle_codecs = 
 permissions = 0777
 post-process = False
 pix-fmt =

--- a/mkvtomp4.py
+++ b/mkvtomp4.py
@@ -55,6 +55,7 @@ class MkvtoMp4:
                  embedsubs=True,
                  embedonlyinternalsubs=True,
                  providers=['addic7ed', 'podnapisi', 'thesubdb', 'opensubtitles'],
+                 additional_bad_subtitle_codecs=None,
                  permissions=int("777", 8),
                  pix_fmt=None,
                  logger=None,
@@ -118,6 +119,7 @@ class MkvtoMp4:
         self.downloadsubs = downloadsubs
         self.subproviders = providers
         self.embedsubs = embedsubs
+        self.additional_bad_subtitle_codecs = additional_bad_subtitle_codecs
         self.embedonlyinternalsubs = embedonlyinternalsubs
         self.subencoding = subencoding
 
@@ -177,6 +179,7 @@ class MkvtoMp4:
         self.sdl = settings.sdl
         self.downloadsubs = settings.downloadsubs
         self.subproviders = settings.subproviders
+        self.additional_bad_subtitle_codecs = settings.additional_bad_subtitle_codecs
         self.embedsubs = settings.embedsubs
         self.embedonlyinternalsubs = settings.embedonlyinternalsubs
         self.subencoding = settings.subencoding
@@ -539,7 +542,7 @@ class MkvtoMp4:
                 self.log.debug("Undefined language detected, defaulting to [%s]." % self.sdl)
                 s.metadata['language'] = self.sdl
             # Make sure its not an image based codec
-            if s.codec.lower() not in bad_subtitle_codecs and self.embedsubs:
+            if s.codec.lower() not in bad_subtitle_codecs and (self.additional_bad_subtitle_codecs is None or s.codec.lower() not in self.additional_bad_subtitle_codecs) and self.embedsubs:
 
                 # Proceed if no whitelist is set, or if the language is in the whitelist
                 if self.swl is None or s.metadata['language'].lower() in self.swl:
@@ -554,7 +557,7 @@ class MkvtoMp4:
                     }})
                     self.log.info("Creating subtitle stream %s from source stream %s." % (l, s.index))
                     l = l + 1
-            elif s.codec.lower() not in bad_subtitle_codecs and not self.embedsubs:
+            elif s.codec.lower() not in bad_subtitle_codecs and (self.additional_bad_subtitle_codecs is None or s.codec.lower() not in self.additional_bad_subtitle_codecs) and not self.embedsubs:
                 if self.swl is None or s.metadata['language'].lower() in self.swl:
 
                     for codec in self.scodec:

--- a/readSettings.py
+++ b/readSettings.py
@@ -111,6 +111,7 @@ class ReadSettings:
                         'embed-subs': 'True',
                         'embed-only-internal-subs': 'False',
                         'sub-providers': 'addic7ed, podnapisi, thesubdb, opensubtitles',
+                        'additional_bad_subtitle_codecs': '',
                         'permissions': '777',
                         'post-process': 'False',
                         'pix-fmt': '',
@@ -344,6 +345,12 @@ class ReadSettings:
             log.warning("You must specifiy at least one subtitle provider to downlaod subs automatically, subtitle downloading disabled.")
         else:
             self.subproviders = self.subproviders.lower().replace(' ', '').split(',')
+
+        self.additional_bad_subtitle_codecs = config.get(section, 'additional_bad_subtitle_codecs').strip().lower()
+        if self.additional_bad_subtitle_codecs == '':
+            self.additional_bad_subtitle_codecs = None
+        else:
+            self.additional_bad_subtitle_codecs = self.additional_bad_subtitle_codecs.replace(' ', '').split(',')
 
         self.embedsubs = config.getboolean(section, 'embed-subs')
 


### PR DESCRIPTION
Relative to #1100 (started because of #1101 )
As I noticed that the list of unsupported subtitles might evolve, I added a parameter in the autoProcess.ini so that we can add potential unsupported subtitles codec in it.
This should prevent to have to edit code to add an unsupported codec and would provide to the users a way to workaround particular issues