### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+setuptools
+requests
+requests[security]
+requests-cache
+babelfish
+tmdbsimple
+mutagen
+guessit
+subliminal
+stevedore #(this will be automatically installed with subliminal)
+python-dateutil #(this will be automatically installed with subliminal)
+qtfaststart
+#deluge-client #optional
+#gevent #optional
+#python-qbittorrent #optional


### PR DESCRIPTION
Would be cool to have this so we did not have to refer to the dependency page every time and copy and paste for new systems.

"pip install -r requirements.txt"

Would install all dependencies.