### PR TITLE
Fix log assignment in postprocess.py

### DIFF
--- a/resources/postprocess.py
+++ b/resources/postprocess.py
@@ -8,7 +8,7 @@ from resources.metadata import MediaType
 
 class PostProcessor:
     def __init__(self, files, logger=None):
-        log = logger or logging.getLogger(__name__)
+        self.log = logger or logging.getLogger(__name__)
 
         self.log.debug("Output: %s." % files)
 


### PR DESCRIPTION
I started encountering a runtime error when trying to log messages in postprocessor.py after pulling in the latest changes, looks like a minor typo from the recent logging changes.