### PR TITLE
Disable Plex refresh by default

### DIFF
--- a/config/autoProcess.ini.sample
+++ b/config/autoProcess.ini.sample
@@ -184,6 +184,6 @@ output-directory =
 [Plex]
 host = localhost
 port = 32400
-refresh = True
+refresh = False
 token = 
 


### PR DESCRIPTION
Current setting is enabled by default, which can cause errors without it being fully configured. Changing the default to disabled will resolve the issue