### PR TITLE
Add ability to set video encoder bitrate based on source video stream bit rate

### DIFF
--- a/converter/__init__.py
+++ b/converter/__init__.py
@@ -165,6 +165,7 @@ class Converter(object):
                     raise ConverterError('Unknown attachment codec error')
 
         if 'video' in opt:
+
             x = opt['video']
             if not isinstance(x, dict) or 'codec' not in x:
                 raise ConverterError('Invalid video codec specification')

--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -49,9 +49,21 @@ class BaseCodec(object):
         safe = ""
         return safe
 
+    # will overwrite bitrate if bt-ratio is set.
+    def check_ratio_video_bitrate(self, opts):
+
+        if 'bt-ratio' in opts:
+            if opts['bt-ratio'] > 0:
+                bitrate_ratio = opts['bt-ratio']
+                bitrate = opts['bitrate']
+                opts['bitrate'] = (bitrate * bitrate_ratio)
+
+        return opts
+
     def safe_options(self, opts):
         safe = {}
 
+        opts = self.check_ratio_video_bitrate(opts)
         # Only copy options that are expected and of correct type
         # (and do typecasting on them)
         for k, v in opts.items():
@@ -62,6 +74,7 @@ class BaseCodec(object):
                 except:
                     pass
         return safe
+
 
 
 class AudioCodec(BaseCodec):
@@ -269,7 +282,7 @@ class VideoCodec(BaseCodec):
     is calculated to preserve the aspect ratio.
 
     Supported video codecs are: null (no video), copy (copy directly
-    from the source), Theora, H.264/AVC, DivX, VP8, H.263, Flv,
+    from the source), Theora, H.265/HEVC, H.264/AVC, DivX, VP8, H.263, Flv,
     MPEG-1, MPEG-2.
     """
 
@@ -354,6 +367,7 @@ class VideoCodec(BaseCodec):
         super(VideoCodec, self).parse_options(opt)
 
         safe = self.safe_options(opt)
+#hi hi {'codec': 'h265', 'map': 0, 'bitrate': 9061, 'crf': -1, 'level': 0.0, 'field_order': 'unknown', 'title': 'FHD', 'src_width': 1920, 'src_height': 1080}
 
         if 'fps' in safe:
             f = safe['fps']
@@ -1516,7 +1530,7 @@ audio_codec_list = [
 ]
 
 video_codec_list = [
-    VideoNullCodec, VideoCopyCodec, TheoraCodec, H264Codec, H264CodecAlt, H264QSVCodec, 
+    VideoNullCodec, VideoCopyCodec, TheoraCodec, H264Codec, H264CodecAlt, H264QSVCodec,
     H265QSVCodecAlt, H265QSVCodec, H265Codec, H265CodecAlt, H265QSVCodecPatched,
     DivxCodec, Vp8Codec, H263Codec, FlvCodec, Mpeg1Codec, NVEncH264Codec, NVEncH265Codec, NVEncH265CodecAlt,
     Mpeg2Codec, H264VAAPICodec, H265VAAPICodec, OMXH264Codec, VideotoolboxEncH264, VideotoolboxEncH265

--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -367,7 +367,6 @@ class VideoCodec(BaseCodec):
         super(VideoCodec, self).parse_options(opt)
 
         safe = self.safe_options(opt)
-#hi hi {'codec': 'h265', 'map': 0, 'bitrate': 9061, 'crf': -1, 'level': 0.0, 'field_order': 'unknown', 'title': 'FHD', 'src_width': 1920, 'src_height': 1080}
 
         if 'fps' in safe:
             f = safe['fps']
@@ -1530,7 +1529,7 @@ audio_codec_list = [
 ]
 
 video_codec_list = [
-    VideoNullCodec, VideoCopyCodec, TheoraCodec, H264Codec, H264CodecAlt, H264QSVCodec,
+    VideoNullCodec, VideoCopyCodec, TheoraCodec, H264Codec, H264CodecAlt, H264QSVCodec, 
     H265QSVCodecAlt, H265QSVCodec, H265Codec, H265CodecAlt, H265QSVCodecPatched,
     DivxCodec, Vp8Codec, H263Codec, FlvCodec, Mpeg1Codec, NVEncH264Codec, NVEncH265Codec, NVEncH265CodecAlt,
     Mpeg2Codec, H264VAAPICodec, H265VAAPICodec, OMXH264Codec, VideotoolboxEncH264, VideotoolboxEncH265

--- a/resources/mediaprocessor.py
+++ b/resources/mediaprocessor.py
@@ -483,8 +483,11 @@ class MediaProcessor:
 
         vcodecs = self.settings.hdr.get('codec', []) if vHDR and len(self.settings.hdr.get('codec', [])) > 0 else self.settings.vcodec
         self.log.debug("Pool of video codecs is %s." % (vcodecs))
-        vcodec = "copy" if info.video.codec in vcodecs else vcodecs[0]
+        vcodec = "copy" if info.video.codec in vcodecs else vcodecs[0]        
+        vbt_ratio = self.settings.vbt_ratio
+        self.log.debug("BT ratio is %s." % (vbt_ratio))
 
+        #if self.settings.vbt_ratio
         # Custom
         try:
             if blockVideoCopy and blockVideoCopy(self, info.video, inputfile):
@@ -595,6 +598,7 @@ class MediaProcessor:
             'codec': vcodec,
             'map': info.video.index,
             'bitrate': vbitrate,
+            'bt-ratio': vbt_ratio,
             'crf': vcrf,
             'maxrate': vmaxrate,
             'bufsize': vbufsize,

--- a/resources/mediaprocessor.py
+++ b/resources/mediaprocessor.py
@@ -483,11 +483,10 @@ class MediaProcessor:
 
         vcodecs = self.settings.hdr.get('codec', []) if vHDR and len(self.settings.hdr.get('codec', [])) > 0 else self.settings.vcodec
         self.log.debug("Pool of video codecs is %s." % (vcodecs))
-        vcodec = "copy" if info.video.codec in vcodecs else vcodecs[0]        
+        vcodec = "copy" if info.video.codec in vcodecs else vcodecs[0]
         vbt_ratio = self.settings.vbt_ratio
         self.log.debug("BT ratio is %s." % (vbt_ratio))
 
-        #if self.settings.vbt_ratio
         # Custom
         try:
             if blockVideoCopy and blockVideoCopy(self, info.video, inputfile):

--- a/resources/readsettings.py
+++ b/resources/readsettings.py
@@ -127,6 +127,7 @@ class ReadSettings:
         },
         'Video': {
             'codec': 'h264, x264',
+            'bt-ratio': "",
             'max-bitrate': 0,
             'crf': -1,
             'crf-profiles': '',
@@ -656,9 +657,9 @@ class ReadSettings:
         # Video
         section = "Video"
         self.vcodec = config.getlist(section, "codec")
+        self.vbt_ratio = config.getfloat(section, "bt-ratio")
         self.vmaxbitrate = config.getint(section, "max-bitrate")
         self.vcrf = config.getint(section, "crf")
-
         self.vcrf_profiles = []
         vcrf_profiles = config.getlist(section, "crf-profiles")
         for vcrfp_raw in vcrf_profiles:

--- a/setup/autoProcess.ini.sample
+++ b/setup/autoProcess.ini.sample
@@ -2,18 +2,18 @@
 ffmpeg = ffmpeg.exe
 ffprobe = ffprobe.exe
 threads = 0
-hwaccels = 
+hwaccels =
 hwaccel-decoders = h264_cuvid, mjpeg_cuvid, mpeg1_cuvid, mpeg2_cuvid, mpeg4_cuvid, vc1_cuvid, hevc_qsv, h264_qsv, hevc_vaapi, h264_vaapi
 hwdevices = vaapi:/dev/dri/renderD128
 hwaccel-output-format = vaapi:vaapi
-output-directory = 
+output-directory =
 output-format = mp4
 output-extension = mp4
-temp-extension = 
+temp-extension =
 minimum-size = 0
 ignored-extensions = nfo, ds_store
-copy-to = 
-move-to = 
+copy-to =
+move-to =
 delete-original = True
 sort-streams = True
 process-same-extensions = False
@@ -22,8 +22,8 @@ force-convert = False
 post-process = False
 wait-post-process = False
 detailed-progress = False
-preopts = 
-postopts = 
+preopts =
+postopts =
 
 [Permissions]
 chmod = 0644
@@ -36,39 +36,39 @@ full-path-guess = True
 tag = True
 tag-language = eng
 download-artwork = poster
-sanitize-disposition = 
+sanitize-disposition =
 
 [Video]
 codec = h264, x264
 max-bitrate = 0
-bt-ratio = 0
+bt-ratio = 
 crf = -1
-crf-profiles = 
-preset = 
-codec-parameters = 
+crf-profiles =
+preset =
+codec-parameters =
 dynamic-parameters = False
 max-width = 0
-profile = 
+profile =
 max-level = 0.0
-pix-fmt = 
-filter = 
+pix-fmt =
+filter =
 force-filter = False
 
 [HDR]
-codec = 
-pix-fmt = 
+codec =
+pix-fmt =
 space = bt2020nc
 transfer = smpte2084
 primaries = bt2020
-preset = 
-codec-parameters = 
-filter = 
+preset =
+codec-parameters =
+filter =
 force-filter = False
 
 [Audio]
 codec = ac3
-languages = 
-default-language = 
+languages =
+default-language =
 first-stream-of-language = False
 allow-language-relax = True
 channel-bitrate = 128
@@ -76,13 +76,13 @@ max-bitrate = 0
 max-channels = 0
 prefer-more-channels = True
 default-more-channels = True
-filter = 
+filter =
 force-filter = False
-sample-rates = 
+sample-rates =
 copy-original = False
 aac-adtstoasc = False
 ignore-truehd = mp4, m4v
-ignored-dispositions = 
+ignored-dispositions =
 unique-dispositions = False
 
 [Universal Audio]
@@ -90,75 +90,75 @@ codec = aac
 channel-bitrate = 128
 first-stream-only = False
 move-after = False
-filter = 
+filter =
 force-filter = False
 
 [Subtitle]
 codec = mov_text
-codec-image-based = 
-languages = 
-default-language = 
+codec-image-based =
+languages =
+default-language =
 first-stream-of-language = False
-encoding = 
+encoding =
 burn-subtitles = False
-burn-dispositions = 
+burn-dispositions =
 download-subs = False
 download-hearing-impaired-subs = False
-download-providers = 
+download-providers =
 embed-subs = True
 embed-image-subs = False
 embed-only-internal-subs = False
 filename-dispositions = forced
 ignore-embedded-subs = False
-ignored-dispositions = 
+ignored-dispositions =
 unique-dispositions = False
-attachment-codec = 
+attachment-codec =
 
 [Sonarr]
 host = localhost
 port = 8989
-apikey = 
+apikey =
 ssl = False
-webroot = 
+webroot =
 force-rename = False
 
 [Radarr]
 host = localhost
 port = 7878
-apikey = 
+apikey =
 ssl = False
-webroot = 
+webroot =
 force-rename = False
 
 [Sickbeard]
 host = localhost
 port = 8081
 ssl = False
-apikey = 
-webroot = 
-username = 
-password = 
+apikey =
+webroot =
+username =
+password =
 
 [Sickrage]
 host = localhost
 port = 8081
 ssl = False
-apikey = 
-webroot = 
-username = 
-password = 
+apikey =
+webroot =
+username =
+password =
 
 [CouchPotato]
 host = localhost
 port = 5050
-username = 
-password = 
-apikey = 
+username =
+password =
+apikey =
 delay = 65
 method = renamer
 delete-failed = False
 ssl = False
-webroot = 
+webroot =
 
 [SABNZBD]
 convert = True
@@ -168,8 +168,8 @@ couchpotato-category = couchpotato
 sonarr-category = sonarr
 radarr-category = radarr
 bypass-category = bypass
-output-directory = 
-path-mapping = 
+output-directory =
+path-mapping =
 
 [Deluge]
 couchpotato-label = couchpotato
@@ -181,11 +181,11 @@ bypass-label = bypass
 convert = True
 host = localhost
 port = 58846
-username = 
-password = 
-output-directory = 
+username =
+password =
+output-directory =
 remove = False
-path-mapping = 
+path-mapping =
 
 [qBittorrent]
 couchpotato-label = couchpotato
@@ -195,15 +195,15 @@ sonarr-label = sonarr
 radarr-label = radarr
 bypass-label = bypass
 convert = True
-action-before = 
-action-after = 
+action-before =
+action-after =
 host = localhost
 port = 8080
 ssl = False
-username = 
-password = 
-output-directory = 
-path-mapping = 
+username =
+password =
+output-directory =
+path-mapping =
 
 [uTorrent]
 couchpotato-label = couchpotato
@@ -214,19 +214,18 @@ radarr-label = radarr
 bypass-label = bypass
 convert = True
 webui = False
-action-before = 
-action-after = 
+action-before =
+action-after =
 host = localhost
 ssl = False
 port = 8080
-username = 
-password = 
-output-directory = 
-path-mapping = 
+username =
+password =
+output-directory =
+path-mapping =
 
 [Plex]
 host = localhost
 port = 32400
 refresh = False
-token = 
-
+token =

--- a/setup/autoProcess.ini.sample
+++ b/setup/autoProcess.ini.sample
@@ -41,6 +41,7 @@ sanitize-disposition =
 [Video]
 codec = h264, x264
 max-bitrate = 0
+bt-ratio = 0
 crf = -1
 crf-profiles = 
 preset = 


### PR DESCRIPTION
Did some work to support a `bt-ratio` configuration option. This value is basically multiplied by the source file's video bit rate to set a new encoding bit rate for the video source.

My use case is mainly around converting my massive video library to hevc where I want to be able to encode at 60% of the source streams bit rate to get basically the same quality since hevc compression is so much better. I'd rather not use `-qp` or `-crf`and have had better results using this, esp vs. setting different `crf-profiles`.

Few notes:

* Setting a `crf` value will still always use `crf` or `qp` for hevc.
* setting a `crf-profile` will override this.
* `max-bitrate` should still kick in (I think)
* basically all `crf` options override `bt-ratio`.

I'm not a Python expert so unsure if my code could be better but Works on my Machine™ 😄 



