### PR TITLE
Attempt to use the bitrate provided from the metadata

### DIFF
--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -220,7 +220,9 @@ class MediaStreamInfo(object):
         elif key == 'duration':
             self.duration = self.parse_float(val)
         elif key == 'bit_rate':
-            self.bitrate = self.parse_int(val, None)
+            br = self.parse_int(val, None)
+            if br is not None and br > 0:
+                self.bitrate = br
         elif key == 'width':
             self.video_width = self.parse_int(val)
         elif key == 'height':
@@ -237,6 +239,9 @@ class MediaStreamInfo(object):
             self.forced = self.parse_bool(self.parse_int(val))
         elif key == 'DISPOSITION:default':
             self.default = self.parse_bool(self.parse_int(val))
+        elif key == 'TAG:bps' or key == 'TAG:BPS':
+            if not self.bitrate:
+                self.bitrate = self.parse_int(val)
 
         if key.startswith('TAG:'):
             key = key.split('TAG:')[1].lower()

--- a/resources/mediaprocessor.py
+++ b/resources/mediaprocessor.py
@@ -357,11 +357,16 @@ class MediaProcessor:
 
     # Estimate the video bitrate
     def estimateVideoBitrate(self, info):
+        # attempt to return the detected video bitrate, if applicable
+        if info.video and info.video.bitrate and info.video.bitrate > 0:
+            return info.video.bitrate / 1000
+
         try:
             total_bitrate = info.format.bitrate
             audio_bitrate = 0
             for a in info.audio:
-                audio_bitrate += a.bitrate
+                if a.bitrate is not None:
+                    audio_bitrate += a.bitrate
 
             self.log.debug("Total bitrate is %s." % info.format.bitrate)
             self.log.debug("Total audio bitrate is %s." % audio_bitrate)


### PR DESCRIPTION
This will generally help avoid, in some circumstances, overestimating the bitrate and re-processing files that have already been processed. This is very useful when `process-same-extensions` is set to `True`.

Open to suggestions on better ways to improve this, this is just my first go at attempting to prevent unnecessary reprocessing.