### PR TITLE
Suggested change to use the bitrate provided from the metadata 

### DIFF
--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -237,9 +237,9 @@ class MediaStreamInfo(object):
             self.forced = self.parse_bool(self.parse_int(val))
         elif key == 'DISPOSITION:default':
             self.default = self.parse_bool(self.parse_int(val))
-        elif key == 'TAG:bps' or key == 'TAG:BPS':
+        elif key.startswith('TAG:bps') or key.startswith('TAG:BPS'):
             if not self.bitrate:
-                self.bitrate = self.parse_int(val)
+                self.bitrate = self.parse_int(val)*(1000 if self.parse_int(val)<1000 else 1)
 
         if key.startswith('TAG:'):
             key = key.split('TAG:')[1].lower()


### PR DESCRIPTION
We wrote before about missing audio bitrate. Found a line I written in generateOptions before.
I changed:

    abitrate = ((a.bitrate / 1000) / a.audio_channels) * audio_channels
to:

    abitrate = (((a.bitrate or int(a.metadata['bps-eng'])) / (1000 if (a.bitrate or int(a.metadata['bps-eng'])) >1000 else 1)) / a.audio_channels) * audio_channels

You written in ffmpeg.py:

        elif key == 'TAG:bps' or key == 'TAG:BPS':
The key in my  line is TAG:BPS-eng  so they add -eng to keys and not write only TAG:BPS, you think it would it be ok to write  key.startswith('TAG:BPS').
I wrote out the  probe data for a file with missing bitrate, the TAG:BPS and bit_rate is missing:

    [STREAM]
    index=0
    codec_name=h264
    bit_rate=N/A
    TAG:BPS-eng=1098999
    [STREAM]
    index=1
    codec_name=aac
    bit_rate=N/A
    TAG:BPS-eng=128398