### PR TITLE
Suggested change to use the bitrate provided from the metadata

### DIFF
--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -238,10 +238,10 @@ class MediaStreamInfo(object):
         elif key == 'DISPOSITION:default':
             self.default = self.parse_bool(self.parse_int(val))
         elif key.lower().startswith('tag:bps'):
-            self.bitrate = self.bitrate or self.parse_int(val)
+            self.bitrate = self.bitrate or self.parse_int(val, None)
 
         if self.bitrate and self.bitrate < 1000:
-            self.bitrate *= 1000
+            self.bitrate = None
 
         if key.startswith('TAG:'):
             key = key.split('TAG:')[1].lower()

--- a/resources/mediaprocessor.py
+++ b/resources/mediaprocessor.py
@@ -365,7 +365,7 @@ class MediaProcessor:
             audio_bitrate = 0
             min_audio_bitrate = 0
             for a in info.audio:
-                audio_bitrate += a.bitrate if a.birate else (baserate * (a.audio_channels or 2))
+                audio_bitrate += a.bitrate if a.bitrate else (baserate * (a.audio_channels or 2))
 
             self.log.debug("Total bitrate is %s." % info.format.bitrate)
             self.log.debug("Total audio bitrate is %s." % audio_bitrate)
@@ -854,6 +854,7 @@ class MediaProcessor:
                 if self.settings.amaxbitrate and abitrate > self.settings.amaxbitrate:
                     self.log.debug("Calculated bitrate of %d exceeds maximum bitrate %d, setting to max value [audio-max-bitrate]." % (abitrate, self.settings.amaxbitrate))
                     abitrate = self.settings.amaxbitrate
+                    acodec = self.settings.acodec[0]
 
                 self.log.debug("Audio codec: %s." % acodec)
                 self.log.debug("Channels: %s." % audio_channels)


### PR DESCRIPTION
Made practical test with file having audio bitrate 196 without fix. Result was that  bitrate 0.196 was indeed send to ffmpeg and a lower limit in ffmpeg set it to 8000(real bitrate 196000) that is if the self.settings.abitrate=0. So the fix for this metadata write error should stay, but for more safety set self.bitrate = None. 
 
The change with self.parse_int(val, None). None value is needed  in code below to raise exception and use self.default_channel_bitrate else  abitrate will end up as 0. None is also used in the other key == 'bit_rate'.

                # Bitrate calculations/overrides
                if self.settings.abitrate == 0:
                    self.log.debug("Attempting to set bitrate based on source stream bitrate.")
                    try:
                        abitrate = ((a.bitrate / 1000) / a.audio_channels) * audio_channels
                    except:
                        self.log.warning("Unable to determine audio bitrate from source stream %s, defaulting to %d per channel." % (a.index, self.default_channel_bitrate))
                        abitrate = audio_channels * self.default_channel_bitrate

The last edit is not related to above but is about sound. When audio bitrate is set to audio-max-bitrate the acodec can still be copy if no other conditions above match as channels,codec,filter so the acodec must also be set to self.settings.acodec[0] there.