### PR TITLE
Rework hardware acceleration decoder selection 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,3 +237,9 @@ pip-log.txt
 ## VS Code
 #################
 .vscode
+
+# PyCharm
+.idea
+
+# pyenv
+.python-version

--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -540,15 +540,25 @@ class FFMpeg(object):
 
     def encoder_formats(self, encoder):
         prefix = "Supported pixel formats:"
-        formatline = next((line.strip() for line in self._get_stdout([self.ffmpeg_path, '-hide_banner', '-h', 'encoder=%s' % encoder]).split('\n')[1:] if line and line.strip().startswith(prefix)), "")
-        formats = formatline.split(":")
-        return formats[1].strip().split(" ") if formats and len(formats) > 0 else []
+        format_line = next((line.strip() for line in self._get_stdout([self.ffmpeg_path, '-hide_banner', '-h', f"encoder={encoder}"]).split('\n')[1:] if line and line.strip().startswith(prefix)), "")
+
+        if format_line:
+            formats = format_line.split(":")
+            if len(formats) > 1:
+                return formats[1].strip().split(" ")
+        else:
+            return []
 
     def decoder_formats(self, decoder):
         prefix = "Supported pixel formats:"
-        formatline = next((line.strip() for line in self._get_stdout([self.ffmpeg_path, '-hide_banner', '-h', 'decoder=%s' % decoder]).split('\n')[1:] if line and line.strip().startswith(prefix)), "")
-        formats = formatline.split(":")
-        return formats[1].strip().split(" ") if formats and len(formats) > 0 else []
+        format_line = next((line.strip() for line in self._get_stdout([self.ffmpeg_path, '-hide_banner', '-h', f"decoder={decoder}"]).split('\n')[1:] if line and line.strip().startswith(prefix)), "")
+
+        if format_line:
+            formats = format_line.split(":")
+            if len(formats) > 1:
+                return formats[1].strip().split(" ")
+        else:
+            return []
 
     @staticmethod
     def _spawn(cmds):

--- a/resources/readsettings.py
+++ b/resources/readsettings.py
@@ -100,6 +100,7 @@ class ReadSettings:
             'threads': 0,
             'hwaccels': '',
             'hwaccel-decoders': '',
+            'hwaccel-decoder-override': '',
             'hwdevices': '',
             'hwaccel-output-format': '',
             'output-directory': '',
@@ -484,6 +485,7 @@ class ReadSettings:
         self.threads = config.getint(section, 'threads')
         self.hwaccels = config.getlist(section, 'hwaccels')
         self.hwaccel_decoders = config.getlist(section, "hwaccel-decoders")
+        self.hwaccel_decoder_override = config.getdict(section, "hwaccel-decoder-override")
         self.hwdevices = config.getdict(section, "hwdevices", lower=False, replace=[])
         self.hwoutputfmt = config.getdict(section, "hwaccel-output-format")
         self.output_dir = config.getdirectory(section, "output-directory")


### PR DESCRIPTION
Bit to explain here... 

tl;dr, I needed a way to force the use of a specific `hwaccel`/`decoder` pair. 

This PR addresses two problems:

1. Improve decoder selection logic to only use decoders that are included in `hwaccel_decoders`.

Currently, the script will attempt to use a decoder that matches `<input codec>_<hwaccel name>`, provided it exists in `ffmpeg -decoders`. The first and largest issue with this approach is that this codec might not actually be supported by the underlying hardware. For example, if the input codec is `av1` and you've provided `cuda` as a hwaccel, then you'll need Nvidia 30-series or later to run the `av1_cuvid` decoder.

Additionally, the script will currently append the first valid (exists in ffmpeg) `hwaccel` it finds.  In my case, even though my GPU didn't support `av1`, I'd like to use my CPU's iGPU to perform the decoding. This PR makes that possible.

2. Users might want to select a specific decoder that doesn't fit the `<input codec>_<hwaccel name>` mold.

I wasn't aware of this, but when trying to solve my use-case I learned that there are internal ffmpeg codecs that support hardware acceleration, and there are external ffmpeg codecs specifically built for a single hardware platform. ffmpeg will implicitly use the internal codec unless you tell it otherwise.

 i.e. you can run the implicit `hevc` decoder with `-hwaccel cuda`, or run `hevc_cuvid` with `-hwaccel cuda`. I don't know too much about how these are maintained separately, but I read that sometimes there are differences in implementation that make one more efficient, so perhaps this will be useful to some.

---

Core problem: there is no good way to query ffmpeg to know if a given decoder is actually going to work with the provided hardware. The only one who knows whether it's going to work is the user. 

Might be helpful to run through my situation to understand why this might be useful.

Hardware:
- GPU: 1650 Super w/ Turing NVENC/NVDEC
- CPU: i12400

Previously, I had
```
[Converter]
...


hwaccel-decoders = h264_cuvid, hevc_cuvid, mjpeg_cuvid, mpeg1_cuvid, mpeg2_cuvid, mpeg4_cuvid, vp8_cuvid, vp9_cuvid
hwdevices = 
hwaccel-output-format = cuda:cuvid
...
[Video]
codec = hevc_nvenc, hevc, h265, x265, h264, x264
...
```

This worked well until I ran into an AV1 file, which failed transcoding 
```
[av1 @ 0x55e6c68fdd80] Hardware is lacking required capabilities
[av1 @ 0x55e6c68fdd80] Failed setup for format cuda: hwaccel initialisation returned error.
[av1 @ 0x55e6c68fdd80] Your platform doesn't support hardware accelerated AV1 decoding.
[av1 @ 0x55e6c68fdd80] Failed to get pixel format.
```

My iGPU supports AV1 decoding, so I figured I could wrangle the settings into performing the decode with that. However, the following fails because the script attempts to use `cuda`.
```
hwaccels = cuda, vaapi
```

However, the script searches for `<input codec>_<hwaccel name>` and there is no `av1_vaapi`. The solution would be to use `-hwaccel vaapi` with `-vcodec av1`.
> `vcodec` would actually be optional due to ffmpeg using it implicitly

Thus the second change. 

If you have a cleaner solution I'm happy to work it out, but I think this works pretty well. I explored modifying the way `hwaccel_decoders` works, where we could detect a listed decoder that wasn't valid according to ffmpeg but corresponded to an internal decoder with hardware acceleration. Adding a new setting to manually specify `hwaccel/decoder` pairings seemed much cleaner and less confusing to users.

